### PR TITLE
No _attributedText ivar in TTTAttributedLabel.h

### DIFF
--- a/TTTAttributedLabel.h
+++ b/TTTAttributedLabel.h
@@ -42,7 +42,7 @@
 typedef NSAttributedString *(^TTTMutableAttributedStringBlock)(NSMutableAttributedString *mutableAttributedString);
 
 @interface TTTAttributedLabel : UILabel <TTTAttributedLabel> {
-    NSMutableAttributedString *_mutableAttributedText;
+    NSAttributedString *_attributedText;
     CTFramesetterRef _framesetter;
     BOOL _needsFramesetter;
     

--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -116,6 +116,7 @@ static inline NSDictionary * NSAttributedStringAttributesFromLabel(UILabel *labe
     [mutableLinkAttributes setValue:(id)[[UIColor blueColor] CGColor] forKey:(NSString*)kCTForegroundColorAttributeName];
     [mutableLinkAttributes setValue:[NSNumber numberWithBool:YES] forKey:(NSString *)kCTUnderlineStyleAttributeName];
     self.linkAttributes = [NSDictionary dictionaryWithDictionary:mutableLinkAttributes];
+    self.attributedText = [[[NSAttributedString alloc] initWithString:@""] autorelease];
     
     return self;
 }


### PR DESCRIPTION
This is from `TTTAttributedLabel.m`:

``` obj-c
@synthesize attributedText = _attributedText;
```

`_attributedText` doesn't appear in the list of ivars.  Instead, `TTTAttributedLabel.h` contains:

``` obj-c
NSMutableAttributedString *_mutableAttributedText;
```

...which is never used in the implementation.

Adding:

``` obj-c
NSAttributedString *_attributedText;
```

to `TTTAttributedLabel.h` and initializing it to an empty `NSAttributedString` in `initWithFrame:` appears to solve the problem.
