### PR TITLE
Source tidies

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -260,7 +260,6 @@ static inline NSDictionary * NSAttributedStringAttributesFromLabel(UILabel *labe
     CTFrameGetLineOrigins(frame, CFRangeMake(0, 0), lineOrigins);
     NSUInteger lineIndex = numberOfLines - 1;
     
-    CGPoint lineOrigin = CGPointZero;
     for (NSUInteger i = 0; i < numberOfLines; i++) {
         CGPoint lineOrigin = lineOrigins[i];
         if(lineOrigin.y > p.y) {
@@ -268,7 +267,7 @@ static inline NSDictionary * NSAttributedStringAttributesFromLabel(UILabel *labe
         }            
     }
     
-    lineOrigin = lineOrigins[lineIndex];
+    CGPoint lineOrigin = lineOrigins[lineIndex];
     CTLineRef line = CFArrayGetValueAtIndex(lines, lineIndex);
     CGPoint relativePoint = CGPointMake(p.x - lineOrigin.x, p.y - lineOrigin.y);
     idx = CTLineGetStringIndexForPosition(line, relativePoint);


### PR DESCRIPTION
Clean up a lot of incorrect floating point constants (i.e., CGFloat, which is of type `float`, should have constants that are non-integer, floating point (1.0) and have a `f` appended to them: `1.0f`).
