### PR TITLE
EXC_BAD_ACCESS in drawFramesetter.

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -353,7 +353,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         NSUInteger numberOfLines = MIN(self.numberOfLines, CFArrayGetCount(lines));
 
         CGPoint lineOrigins[numberOfLines];
-        CTFrameGetLineOrigins(frame, CFRangeMake(0, 0), lineOrigins);
+        CTFrameGetLineOrigins(frame, CFRangeMake(0, numberOfLines), lineOrigins);
         
         for (NSUInteger lineIndex = 0; lineIndex < numberOfLines; lineIndex++) {
             CGPoint lineOrigin = lineOrigins[lineIndex];


### PR DESCRIPTION
I had a few crashes in drawFramesetter that only reared their head in Release build configs (despite all build settings being identical), and seemed tied to compiler optimization.
I had a poke around and found the error was some funky array index issues with CTFrameGetLineOrigins, if passed 0 range this will traverse the array for all CGPoints, but this seemed to be causing the issue. Passing numberOfLines as a range seemed to solve this.

The thing is, that doesn't really make sense. It should be numberOfLines-1, but that throws off the framesetter completely. You probably know a lot more about CT than I do so maybe you understand this better.

---

Changed drawFramesetters CTFrameGetLineOrigins method to use a hard range based on numberOfLines, rather than automatic array traversal.
