### PR TITLE
Touch Fixes

### DIFF
--- a/TTTAttributedLabel.h
+++ b/TTTAttributedLabel.h
@@ -58,6 +58,7 @@ typedef enum {
     
     id _delegate;
     UIDataDetectorTypes _dataDetectorTypes;
+    NSDataDetector *_dataDetector;
     NSArray *_links;
     NSDictionary *_linkAttributes;
     

--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -122,7 +122,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 @property (readwrite, nonatomic, assign) CTFramesetterRef highlightFramesetter;
 @property (readwrite, nonatomic, retain) NSArray *links;
 
-- (id)initCommon;
+- (id)commonInit;
 - (void)setNeedsFramesetter;
 - (NSArray *)detectedLinksInString:(NSString *)string range:(NSRange)range error:(NSError **)error;
 - (NSTextCheckingResult *)linkAtCharacterIndex:(CFIndex)idx;
@@ -153,7 +153,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         return nil;
     }
     
-    return [self initCommon];
+    return [self commonInit];
 }
 
 - (id)initWithCoder:(NSCoder *)coder {
@@ -162,10 +162,10 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         return nil;
     }
     
-    return [self initCommon];
+    return [self commonInit];
 }
 
-- (id)initCommon {
+- (id)commonInit {
     self.dataDetectorTypes = UIDataDetectorTypeNone;
     self.links = [NSArray array];
     
@@ -191,6 +191,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     [_links release];
     [_linkAttributes release];
     [_tapRecognizer release];
+    [_dataDetector release];
     [super dealloc];
 }
 
@@ -230,13 +231,22 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 
 #pragma mark -
 
+- (void)setDataDetectorTypes:(UIDataDetectorTypes)newTypes {
+    [_dataDetector release];
+    if (newTypes == UIDataDetectorTypeNone) {
+        _dataDetector = nil;
+    } else {
+        _dataDetector = [[NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeFromUIDataDetectorType(newTypes) error:NULL] retain];
+    }
+    _dataDetectorTypes = newTypes;
+}
+
 - (NSArray *)detectedLinksInString:(NSString *)string range:(NSRange)range error:(NSError **)error {
     if (!string) {
         return [NSArray array];
     }
     NSMutableArray *mutableLinks = [NSMutableArray array];
-    NSDataDetector *dataDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeFromUIDataDetectorType(self.dataDetectorTypes) error:error];
-    [dataDetector enumerateMatchesInString:string options:0 range:range usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
+    [_dataDetector enumerateMatchesInString:string options:0 range:range usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
         [mutableLinks addObject:result];
     }];
     


### PR DESCRIPTION
OK, I agree that having a generic UITableViewCell class is probably not a good idea.

But, using a UIGestureRecognizer is! Here's the UIGestureRecognizer fix independent of the UITableViewCell subclass, plus a performance fix (creating NSDataDetectors was about ~5% of time spent in an Instruments session, with the rest in text layout; there's no reason to create it over and over).
