### PR TITLE
Improve sizeThatFits:

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -528,9 +528,14 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     }
     
     CFRange rangeToSize = CFRangeMake(0, [self.attributedText length]);
+    CGSize constraints = CGSizeMake(size.width, CGFLOAT_MAX);
     
-    // If the line count of the label isn't 0, limit the range to size to the number of lines that have been set
-    if (self.numberOfLines > 0) {
+    if (self.numberOfLines == 1) {
+        // If there is one line, the size that fits is the full width of the line
+        constraints = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
+    }
+    else if (self.numberOfLines > 0) {
+        // If the line count of the label more than 1, limit the range to size to the number of lines that have been set
         CGMutablePathRef path = CGPathCreateMutable();
         CGPathAddRect(path, NULL, CGRectMake(0, 0, self.bounds.size.width, CGFLOAT_MAX));
 
@@ -549,7 +554,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         CFRelease(path);
     }
     
-    CGSize suggestedSize = CTFramesetterSuggestFrameSizeWithConstraints(self.framesetter, rangeToSize, NULL, CGSizeMake(size.width, CGFLOAT_MAX), NULL);
+    CGSize suggestedSize = CTFramesetterSuggestFrameSizeWithConstraints(self.framesetter, rangeToSize, NULL, constraints, NULL);
     return CGSizeMake(ceilf(suggestedSize.width), ceilf(suggestedSize.height));
 }
 


### PR DESCRIPTION
These commits update sizeThatFits: to take into consideration the label's numberOfLines value
- If numberOfLines is 0, the size returned the same as the current implementation. It's limited to the width of the label but enough height to contain all the text.
- If the number of lines is 1, the size returned is the size of all the text on a single line
- If the number if lines is greater than 1, the size returned is limited to the width of the label and the number of lines of text specified.
