### PR TITLE
Refresh attributes when needed

### DIFF
--- a/TTTAttributedLabel.h
+++ b/TTTAttributedLabel.h
@@ -56,6 +56,8 @@ typedef enum {
     CTFramesetterRef _framesetter;
     BOOL _needsFramesetter;
     
+    BOOL _needsAttributes;
+    
     id _delegate;
     UIDataDetectorTypes _dataDetectorTypes;
     NSDataDetector *_dataDetector;
@@ -164,7 +166,7 @@ typedef enum {
  Sets the text displayed by the label.
  
  @param text An `NSString` or `NSAttributedString` object to be displayed by the label. If the specified text is an `NSString`, the label will display the text like a `UILabel`, inheriting the text styles of the label. If the specified text is an `NSAttributedString`, the label text styles will be overridden by the styles specified in the attributed string.
-  
+ 
  @discussion This method overrides `UILabel -setText:` to accept both `NSString` and `NSAttributedString` objects. This string is `nil` by default.
  */
 - (void)setText:(id)text;


### PR DESCRIPTION
The current commits assume that the label doesn't change after setting the attributedText/text property. This leaded to ignore textAlignment, lineBreakMode etc. Here's the fix.
