### PR TITLE
Add block handlers to handle tapped links

### DIFF
--- a/TTTAttributedLabel.h
+++ b/TTTAttributedLabel.h
@@ -71,6 +71,7 @@ typedef enum {
     TTTAttributedLabelVerticalAlignment _verticalAlignment;
     
     UITapGestureRecognizer *_tapGestureRecognizer;
+    NSMutableDictionary *_linkHandlers;
 }
 
 ///-----------------------------
@@ -198,6 +199,8 @@ typedef enum {
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
  */
 - (void)addLinkToURL:(NSURL *)url withRange:(NSRange)range;
+
+- (void)addLinkToURL:(NSURL *)url withRange:(NSRange)range handler:(void(^)())handler;
 
 /**
  Adds a link to an address for a specified range in the label text.

--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -184,6 +184,8 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     [mutableLinkAttributes setValue:[NSNumber numberWithBool:YES] forKey:(NSString *)kCTUnderlineStyleAttributeName];
     self.linkAttributes = [NSDictionary dictionaryWithDictionary:mutableLinkAttributes];
     
+    _linkHandlers = [[NSMutableDictionary alloc] init];
+    
     self.textInsets = UIEdgeInsetsZero;
     
     self.userInteractionEnabled = YES;
@@ -275,6 +277,11 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 
 - (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result {
     [self addLinkWithTextCheckingResult:result attributes:self.linkAttributes];
+}
+
+- (void)addLinkToURL:(NSURL *)url withRange:(NSRange)range handler:(void(^)())handler {
+    if (handler != NULL) [_linkHandlers setObject:[handler copy] forKey:url];
+    [self addLinkToURL:url withRange:range];
 }
 
 - (void)addLinkToURL:(NSURL *)url withRange:(NSRange)range {
@@ -551,15 +558,19 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     }
     
     NSTextCheckingResult *result = [self linkAtPoint:[gestureRecognizer locationInView:self]];
-    if (!result || !self.delegate) {
+    if (!result) {
         return;
     }
     
     switch (result.resultType) {
-        case NSTextCheckingTypeLink:
+        case NSTextCheckingTypeLink:{
+            void (^handler)() = [_linkHandlers objectForKey:result.URL];
+            if (handler) handler();
+            
             if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
                 [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
             }
+        }
             break;
         case NSTextCheckingTypeAddress:
             if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {


### PR DESCRIPTION
I've added block handlers as a new method for link types only. I don't need them for other types, so I didn't know whether to implement them for those too. As you can see it's fairly trivial to add, but maybe no-one else wants them. :)

Another point about this is that if you add two links to the same URL, the first block will be unset in the link handlers dictionary. This again is fine for me because my handlers would do the same anyway, but another way might be to use the range to further unique each URL?
