### PR TITLE
[Issue #50] TTTAttributedLabelVerticalAlignmentCenter and numberOfLines > 0

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -374,6 +374,8 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         
         for (NSUInteger lineIndex = 0; lineIndex < numberOfLines; lineIndex++) {
             CGPoint lineOrigin = lineOrigins[lineIndex];
+            lineOrigin.x += rect.origin.x;
+            lineOrigin.y += rect.origin.y;
             CGContextSetTextPosition(c, lineOrigin.x, lineOrigin.y);
             CTLineRef line = CFArrayGetValueAtIndex(lines, lineIndex);
             CTLineDraw(line, c);


### PR DESCRIPTION
Fix for verticalAlignment not working correctly when set to TTTAttributedLabelVerticalAlignmentCenter and numberOfLines greater than 0

This is the same issue as #51 but i realized that i did the pull request incorrectly, so I'm closing that one and doing this one. Sorry @mattt!
