### PR TITLE
Fix for CTFramesetterSuggestFrameSizeWithConstraints bug in iOS 4

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -460,7 +460,8 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 
     // First, adjust the text to be in the center vertically, if the text size is smaller than the drawing rect
     CGSize textSize = CTFramesetterSuggestFrameSizeWithConstraints(self.framesetter, textRange, NULL, textRect.size, &fitRange);
-    
+    textSize.height = ceil(textSize.height); // fix for iOS 4, CTFramesetterSuggestFrameSizeWithConstraints sometimes returns sizes that are ever so slightly too small
+
     if (textSize.height < textRect.size.height) {
         CGFloat yOffset = 0.0f;
         CGFloat heightChange = (textRect.size.height - textSize.height);


### PR DESCRIPTION
CTFramesetterSuggestFrameSizeWithConstraints returns heights that are very slightly too small for small point sizes which sometimes results in the last line of text not being drawn or worse: if you only had one line of text, no text being drawn. See issue #52 for more information.

Thanks to @VilemKurz for verifying this.
