### PR TITLE
Be careful not to crash in characterIndexAtPoint:

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -331,6 +331,10 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathAddRect(path, NULL, textRect);
     CTFrameRef frame = CTFramesetterCreateFrame(self.framesetter, CFRangeMake(0, [self.attributedText length]), path, NULL);
+    if (frame == NULL) {
+        CFRelease(path);
+        return NSNotFound;
+    }
     CFArrayRef lines = CTFrameGetLines(frame);
     NSUInteger numberOfLines = CFArrayGetCount(lines);
     if (numberOfLines == 0) {


### PR DESCRIPTION
If you don't have any lines in the framesetter at all, `characterIndexAtPoint:` would crash by attempting to read from index 0. Work around this neatly by returning `NSNotFound` in this case.
