### PR TITLE
fix for issue #64

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -432,7 +432,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
                                 truncationType = kCTLineTruncationEnd;
                                 break;
                         }    
-                        CTLineRef truncatedLine = CTLineCreateTruncatedLine(line, CTLineGetImageBounds(line, c).size.width, truncationType, truncationToken);
+                        CTLineRef truncatedLine = CTLineCreateTruncatedLine(line, rect.size.width, truncationType, truncationToken);
                         CTLineDraw(truncatedLine, c);
                         CFRelease(truncatedLine);
                     }


### PR DESCRIPTION
if there is more than 1 line, only do tail truncation

head and middle truncation don't make sense in this case because we
truncate at the line level and not at the entire text level.
