### PR TITLE
Part of issue65 didn't make it through the merge

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -470,7 +470,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
                         // Truncate the line in case it is too long.
                         CTLineRef truncatedLine = CTLineCreateTruncatedLine(stringWithTokenLine, rect.size.width, kCTLineTruncationEnd, truncationToken);
                         if (!truncatedLine) {
-                            // if the line is less wide than the truncationToken, truncatedLine is NULL
+                            // If the line is not as wide as the truncationToken, truncatedLine is NULL
                             truncatedLine = CFRetain(truncationToken);
                         }
                         CTLineDraw(truncatedLine, c);


### PR DESCRIPTION
The merge for issue #65 missed a couple lines.

Fix for crash when truncating a line and the truncated part is shorter then the truncation token.

The part that fixed it for multiline labels didn't make it into the merge.
