### PR TITLE
Fix for link detection inaccuracy

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -337,6 +337,8 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         return NSNotFound;
     }
     
+    // Offset tap coordinates by textRect origin to make them relative to the origin of frame
+    p = CGPointMake(p.x - textRect.origin.x, p.y - textRect.origin.y);
     // Convert tap coordinates (start at top left) to CT coordinates (start at bottom left)
     p = CGPointMake(p.x, textRect.size.height - p.y);
 


### PR DESCRIPTION
Override `-textRectForBounds:limitedToNumberOfLines:`

The text rect we were getting using
`-textRectForBounds:limitedToNumberOfLines:` in `-characterIndexAtPoint:`
was incorrect because it was not taking our attributed string into
account.

We were not correctly finding links if text was smaller than bounds
because the text rect was not taking our vertical centering into
affect. In addition, links towards the end of the string could be cut
off because the text rect we were getting back was for a regular string
and not our attributed string which could be bigger (for example if it
was bold).

We already had the correct code for handling this in `-drawTextInRect:`.
I simply moved the code into `-textRectForBounds:limitedToNumberOfLines:`
which makes a lot of sense.
