### PR TITLE
Allow other text checking result types

### DIFF
--- a/TTTAttributedLabel.h
+++ b/TTTAttributedLabel.h
@@ -303,10 +303,11 @@ extern NSString * const kTTTStrikeOutAttributeName;
 - (void)attributedLabel:(TTTAttributedLabel *)label didSelectLinkWithDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone duration:(NSTimeInterval)duration;
 
 /**
- Tells the delegate that the user did select a link to a custom text checking result.
+ Tells the delegate that the user did select a link to a text checking result.
+ This method is called if the text checking result is custom or you do not implement a method that handles it.
  
  @param label The label whose link was selected.
  @param result The custom text checking result.
  */
-- (void)attributedLabel:(TTTAttributedLabel *)label didSelectLinkWithCustomTextCheckingResult:(NSTextCheckingResult *)result;
+- (void)attributedLabel:(TTTAttributedLabel *)label didSelectLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
 @end

--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -722,34 +722,41 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         return;
     }
     
+    BOOL handled = NO;
     switch (result.resultType) {
         case NSTextCheckingTypeLink:
             if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
                 [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
+                handled = YES;
             }
             break;
         case NSTextCheckingTypeAddress:
             if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
                 [self.delegate attributedLabel:self didSelectLinkWithAddress:result.addressComponents];
+                handled = YES;
             }
             break;
         case NSTextCheckingTypePhoneNumber:
             if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
                 [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:result.phoneNumber];
+                handled = YES;
             }
             break;
         case NSTextCheckingTypeDate:
             if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
                 [self.delegate attributedLabel:self didSelectLinkWithDate:result.date timeZone:result.timeZone duration:result.duration];
+                handled = YES;
             } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
                 [self.delegate attributedLabel:self didSelectLinkWithDate:result.date];
+                handled = YES;
             }
             break;
-        default:
-            if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithCustomTextCheckingResult:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithCustomTextCheckingResult:result];
-            }
-            break;
+    }
+    
+    if (!handled) {
+        if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
+            [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
+        }
     }
 }
 


### PR DESCRIPTION
This pull allows `TTTAttributeLabel` to take any type of text checking results including other built in types and custom `NSTextCheckingResult` subclasses.
- Make `- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result` public so you can add other types of text checking results with the previously set built in link attributes.
- Add delegate method `- (void)attributedLabel:(TTTAttributedLabel *)label didSelectLinkWithTextCheckingResult:(NSTextCheckingResult *)result` which is called if a text checking result is not handled (either because none of the other delegate methods can handle it or they aren't implemented).

What do you think?
