### PR TITLE
Any links in the last line of an attributed label are untappable

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -363,7 +363,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     CGPoint lineOrigins[numberOfLines];
     CTFrameGetLineOrigins(frame, CFRangeMake(0, 0), lineOrigins);
 
-    for (CFIndex lineIndex = 0; lineIndex < (numberOfLines - 1); lineIndex++) {
+    for (CFIndex lineIndex = 0; lineIndex < numberOfLines; lineIndex++) {
         CGPoint lineOrigin = lineOrigins[lineIndex];
         CTLineRef line = CFArrayGetValueAtIndex(lines, lineIndex);
         


### PR DESCRIPTION
It looks like this line got messed up in all the merge craziness (commit e4a57).

Besides this line it looks like all my patches made it in safely without any mixups. Thanks Mattt :)
