### PR TITLE
Fixed a regression caused by a641a21fa146542585e15e3ea3a7f133bee31c8d that makes a long, top aligned label sometimes not draw the last line

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -614,9 +614,11 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     textSize = CGSizeMake(ceilf(textSize.width), ceilf(textSize.height)); // Fix for iOS 4, CTFramesetterSuggestFrameSizeWithConstraints sometimes returns fractional sizes
     
     if (textSize.height < textRect.size.height) {
+        CGFloat heightChange = (textRect.size.height - textSize.height);
         CGFloat yOffset = 0.0f;
         switch (self.verticalAlignment) {
             case TTTAttributedLabelVerticalAlignmentTop:
+                heightChange = 0.0f;
                 break;
             case TTTAttributedLabelVerticalAlignmentCenter:
                 yOffset = floorf((textRect.size.height - textSize.height) / 2.0f);
@@ -627,7 +629,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         }
         
         textRect.origin.y += yOffset;
-        textRect.size.height = textSize.height;
+        textRect.size = CGSizeMake(textRect.size.width, textRect.size.height - heightChange + yOffset);
     }
     
     return textRect;


### PR DESCRIPTION
The bug can be triggered by having the alignment being
TTTAttributedLabelVerticalAlignmentTop and lineHeightMultiple being
greater than 1 (1.03, for example). Matt's old code handled this well,
but a641a21fa146542585e15e3ea3a7f133bee31c8d broke it.
