### PR TITLE
Fixed a crash caused by loading TTTAttributedLabel from a UIStoryboard

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -165,6 +165,19 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 @synthesize verticalAlignment = _verticalAlignment;
 @synthesize tapGestureRecognizer = _tapGestureRecognizer;
 
+- (UIColor*)textColor
+{
+	UIColor *clr = [super textColor];
+	
+	if(!clr)
+	{
+		clr = [UIColor blackColor];
+		self.textColor = clr;
+	}
+	
+	return clr;
+}
+
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (!self) {
@@ -404,7 +417,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     CFArrayRef lines = CTFrameGetLines(frame);
     NSInteger numberOfLines = self.numberOfLines > 0 ? MIN(self.numberOfLines, CFArrayGetCount(lines)) : CFArrayGetCount(lines);
     BOOL truncateLastLine = (self.lineBreakMode == UILineBreakModeHeadTruncation || self.lineBreakMode == UILineBreakModeMiddleTruncation || self.lineBreakMode == UILineBreakModeTailTruncation);
-    
+	
     CGPoint lineOrigins[numberOfLines];
     CTFrameGetLineOrigins(frame, CFRangeMake(0, numberOfLines), lineOrigins);
     


### PR DESCRIPTION
When TTTAttributedLabel is set as the class for a UIView used in a UIStoryboard it will be created without a textColor. This will cause a crash when text is assigned to the label because NSAttributedStringAttributesFromLabel() attempts to assign a nil CGColor to the attribute dictionary. TTTAttributedLabel now defaults to black if no textColor has been set.
