### PR TITLE
- use `copy` mem prop attribute

### DIFF
--- a/TTTAttributedLabelExample/TTTAttributedLabelExample/AttributedTableViewCell.h
+++ b/TTTAttributedLabelExample/TTTAttributedLabelExample/AttributedTableViewCell.h
@@ -26,7 +26,7 @@
 
 @interface AttributedTableViewCell : UITableViewCell
 
-@property (nonatomic, strong) NSString *summaryText;
+@property (nonatomic, copy) NSString *summaryText;
 @property (nonatomic, strong) TTTAttributedLabel *summaryLabel;
 
 + (CGFloat)heightForCellWithText:(NSString *)text;


### PR DESCRIPTION
Copy is preferred, since that is how its also used by the implementation (ivar)
