### PR TITLE
Show active link appearance

### DIFF
--- a/TTTAttributedLabel.h
+++ b/TTTAttributedLabel.h
@@ -95,6 +95,11 @@ extern NSString * const kTTTStrikeOutAttributeName;
  */
 @property (nonatomic, strong) NSDictionary *linkAttributes;
 
+/**
+ A dictionary containing the `NSAttributedString` attributes to be applied to links when they are in the active state. Supply `nil` or an empty dictionary to opt out of active link styling. The default active link style is red and underlined.
+ */
+@property (nonatomic, strong) NSDictionary *activeLinkAttributes;
+
 ///---------------------------------------
 /// @name Acccessing Text Style Attributes
 ///---------------------------------------

--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -130,11 +130,12 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 
 @interface TTTAttributedLabel ()
 @property (readwrite, nonatomic, copy) NSAttributedString *attributedText;
+@property (readwrite, nonatomic, copy) NSAttributedString *inactiveAttributedText;
 @property (readwrite, nonatomic, assign) CTFramesetterRef framesetter;
 @property (readwrite, nonatomic, assign) CTFramesetterRef highlightFramesetter;
 @property (readwrite, nonatomic, strong) NSDataDetector *dataDetector;
 @property (readwrite, nonatomic, strong) NSArray *links;
-@property (readwrite, nonatomic, strong) UITapGestureRecognizer *tapGestureRecognizer;
+@property (readwrite, nonatomic, strong) NSTextCheckingResult *activeLink;
 
 - (void)commonInit;
 - (void)setNeedsFramesetter;
@@ -144,7 +145,6 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 - (CFIndex)characterIndexAtPoint:(CGPoint)p;
 - (void)drawFramesetter:(CTFramesetterRef)framesetter textRange:(CFRange)textRange inRect:(CGRect)rect context:(CGContextRef)c;
 - (void)drawStrike:(CTFrameRef)frame inRect:(CGRect)rect context:(CGContextRef)c;
-- (void)handleTap:(UITapGestureRecognizer *)gestureRecognizer;
 @end
 
 @implementation TTTAttributedLabel {
@@ -154,6 +154,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 
 @dynamic text;
 @synthesize attributedText = _attributedText;
+@synthesize inactiveAttributedText = _inactiveAttributedText;
 @synthesize framesetter = _framesetter;
 @synthesize highlightFramesetter = _highlightFramesetter;
 @synthesize delegate = _delegate;
@@ -161,13 +162,14 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
 @synthesize dataDetector = _dataDetector;
 @synthesize links = _links;
 @synthesize linkAttributes = _linkAttributes;
+@synthesize activeLinkAttributes = _activeLinkAttributes;
 @synthesize shadowRadius = _shadowRadius;
 @synthesize leading = _leading;
 @synthesize lineHeightMultiple = _lineHeightMultiple;
 @synthesize firstLineIndent = _firstLineIndent;
 @synthesize textInsets = _textInsets;
 @synthesize verticalAlignment = _verticalAlignment;
-@synthesize tapGestureRecognizer = _tapGestureRecognizer;
+@synthesize activeLink = _activeLink;
 
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
@@ -200,18 +202,20 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     [mutableLinkAttributes setValue:[NSNumber numberWithBool:YES] forKey:(NSString *)kCTUnderlineStyleAttributeName];
     self.linkAttributes = [NSDictionary dictionaryWithDictionary:mutableLinkAttributes];
     
+    NSMutableDictionary *mutableActiveLinkAttributes = [NSMutableDictionary dictionary];
+    [mutableActiveLinkAttributes setValue:(id)[[UIColor redColor] CGColor] forKey:(NSString*)kCTForegroundColorAttributeName];
+    [mutableActiveLinkAttributes setValue:[NSNumber numberWithBool:YES] forKey:(NSString *)kCTUnderlineStyleAttributeName];
+    self.activeLinkAttributes = [NSDictionary dictionaryWithDictionary:mutableActiveLinkAttributes];
+    
     self.textInsets = UIEdgeInsetsZero;
     
     self.userInteractionEnabled = YES;
-    self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
-    [self.tapGestureRecognizer setDelegate:self];
-    [self addGestureRecognizer:self.tapGestureRecognizer];
+    self.multipleTouchEnabled = NO;
 }
 
 - (void)dealloc {
     if (_framesetter) CFRelease(_framesetter);
     if (_highlightFramesetter) CFRelease(_highlightFramesetter);
-    
 }
 
 #pragma mark -
@@ -245,6 +249,31 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     }
     
     return _framesetter;
+}
+
+#pragma mark -
+
+- (void)setLinkActive:(BOOL)active withTextCheckingResult:(NSTextCheckingResult *)result {
+    if (result && [self.activeLinkAttributes count] > 0) {
+        if (active) {
+            if (!self.inactiveAttributedText) {
+                self.inactiveAttributedText = self.attributedText;
+            }
+            
+            NSMutableAttributedString *mutableAttributedString = [self.inactiveAttributedText mutableCopy];
+            [mutableAttributedString addAttributes:self.activeLinkAttributes range:result.range];
+            self.attributedText = mutableAttributedString;
+            
+            [self setNeedsDisplay];
+        } else {
+            if (self.inactiveAttributedText) {
+                self.attributedText = self.inactiveAttributedText;
+                self.inactiveAttributedText = nil;
+                
+                [self setNeedsDisplay];
+            }
+        }
+    }
 }
 
 #pragma mark -
@@ -738,57 +767,92 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
     return CGSizeMake(ceilf(suggestedSize.width), ceilf(suggestedSize.height));
 }
 
-#pragma mark - UIGestureRecognizer
+#pragma mark - Touch Events
 
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
-    return [self linkAtPoint:[touch locationInView:self]] != nil;
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+    UITouch *touch = [touches anyObject];
+    
+    self.activeLink = [self linkAtPoint:[touch locationInView:self]];
+        
+    if (self.activeLink) {
+        [self setLinkActive:YES withTextCheckingResult:self.activeLink];
+    } else {
+        [super touchesBegan:touches withEvent:event];
+    }
 }
 
-- (void)handleTap:(UITapGestureRecognizer *)gestureRecognizer {
-    if ([gestureRecognizer state] != UIGestureRecognizerStateEnded) {
-        return;
+- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {    
+    if (self.activeLink) {
+        UITouch *touch = [touches anyObject];
+        
+        if (self.activeLink != [self linkAtPoint:[touch locationInView:self]]) {
+            [self setLinkActive:NO withTextCheckingResult:self.activeLink];
+        } else {
+            [self setLinkActive:YES withTextCheckingResult:self.activeLink];
+        }
+    } else {
+        [super touchesMoved:touches withEvent:event];
     }
-    
-    NSTextCheckingResult *result = [self linkAtPoint:[gestureRecognizer locationInView:self]];
-    if (!result || !self.delegate) {
-        return;
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+    if (self.activeLink) {
+        UITouch *touch = [touches anyObject];
+        if (self.activeLink == [self linkAtPoint:[touch locationInView:self]]) {
+            [self setLinkActive:NO withTextCheckingResult:self.activeLink];
+            
+            if (!self.delegate) {
+                return;
+            }
+            
+            NSTextCheckingResult *result = self.activeLink;
+            switch (result.resultType) {
+                case NSTextCheckingTypeLink:
+                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
+                        [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
+                        return;
+                    }
+                    break;
+                case NSTextCheckingTypeAddress:
+                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
+                        [self.delegate attributedLabel:self didSelectLinkWithAddress:result.addressComponents];
+                        return;
+                    }
+                    break;
+                case NSTextCheckingTypePhoneNumber:
+                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
+                        [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:result.phoneNumber];
+                        return;
+                    }
+                    break;
+                case NSTextCheckingTypeDate:
+                    if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
+                        [self.delegate attributedLabel:self didSelectLinkWithDate:result.date timeZone:result.timeZone duration:result.duration];
+                        return;
+                    } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
+                        [self.delegate attributedLabel:self didSelectLinkWithDate:result.date];
+                        return;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            
+            // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
+            if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
+                [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
+            }
+        }
+    } else {
+        [super touchesEnded:touches withEvent:event];
     }
-    
-    switch (result.resultType) {
-        case NSTextCheckingTypeLink:
-            if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
-                return;
-            }
-            break;
-        case NSTextCheckingTypeAddress:
-            if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithAddress:result.addressComponents];
-                return;
-            }
-            break;
-        case NSTextCheckingTypePhoneNumber:
-            if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:result.phoneNumber];
-                return;
-            }
-            break;
-        case NSTextCheckingTypeDate:
-            if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithDate:result.date timeZone:result.timeZone duration:result.duration];
-                return;
-            } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithDate:result.date];
-                return;
-            }
-            break;
-		default:
-			break;
-    }
-    
-    // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
-    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
-        [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
+}
+
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
+    if (self.activeLink) {
+        [self setLinkActive:NO withTextCheckingResult:self.activeLink];
+    } else {
+        [super touchesCancelled:touches withEvent:event];
     }
 }
 

--- a/TTTAttributedLabelExample/TTTAttributedLabelExample.xcodeproj/project.pbxproj
+++ b/TTTAttributedLabelExample/TTTAttributedLabelExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D925D8B915C81E60002842A4 /* EspressoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D925D8B815C81E60002842A4 /* EspressoViewController.m */; };
 		F877A36113782AF10022A8AB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F877A36013782AF10022A8AB /* UIKit.framework */; };
 		F877A36313782AF10022A8AB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F877A36213782AF10022A8AB /* Foundation.framework */; };
 		F877A36513782AF10022A8AB /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F877A36413782AF10022A8AB /* CoreGraphics.framework */; };
@@ -20,6 +21,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		D925D8B715C81E60002842A4 /* EspressoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EspressoViewController.h; sourceTree = "<group>"; };
+		D925D8B815C81E60002842A4 /* EspressoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EspressoViewController.m; sourceTree = "<group>"; };
 		F877A35C13782AF10022A8AB /* Espressos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Espressos.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F877A36013782AF10022A8AB /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		F877A36213782AF10022A8AB /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -121,6 +124,8 @@
 			children = (
 				F877A37513782AF10022A8AB /* RootViewController.h */,
 				F877A37613782AF10022A8AB /* RootViewController.m */,
+				D925D8B715C81E60002842A4 /* EspressoViewController.h */,
+				D925D8B815C81E60002842A4 /* EspressoViewController.m */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -210,6 +215,7 @@
 				F877A37713782AF10022A8AB /* RootViewController.m in Sources */,
 				F877A39813782FF50022A8AB /* AttributedTableViewCell.m in Sources */,
 				F877A38213782B360022A8AB /* TTTAttributedLabel.m in Sources */,
+				D925D8B915C81E60002842A4 /* EspressoViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TTTAttributedLabelExample/TTTAttributedLabelExample/EspressoViewController.h
+++ b/TTTAttributedLabelExample/TTTAttributedLabelExample/EspressoViewController.h
@@ -1,0 +1,29 @@
+// EspressoViewController.h
+//
+// Copyright (c) 2011 Mattt Thompson (http://mattt.me)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <UIKit/UIKit.h>
+
+@interface EspressoViewController : UIViewController
+
+@property (nonatomic, copy) NSString *espresso;
+
+@end

--- a/TTTAttributedLabelExample/TTTAttributedLabelExample/EspressoViewController.m
+++ b/TTTAttributedLabelExample/TTTAttributedLabelExample/EspressoViewController.m
@@ -1,0 +1,149 @@
+// EspressoViewController.m
+//
+// Copyright (c) 2011 Mattt Thompson (http://mattt.me)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "EspressoViewController.h"
+#import "TTTAttributedLabel.h"
+
+static CGFloat const kSummaryTextFontSize = 17;
+
+static NSRegularExpression *__nameRegularExpression;
+static inline NSRegularExpression * NameRegularExpression() {
+    if (!__nameRegularExpression) {
+        __nameRegularExpression = [[NSRegularExpression alloc] initWithPattern:@"^\\w+" options:NSRegularExpressionCaseInsensitive error:nil];
+    }
+    
+    return __nameRegularExpression;
+}
+
+static NSRegularExpression *__parenthesisRegularExpression;
+static inline NSRegularExpression * ParenthesisRegularExpression() {
+    if (!__parenthesisRegularExpression) {
+        __parenthesisRegularExpression = [[NSRegularExpression alloc] initWithPattern:@"\\([^\\(\\)]+\\)" options:NSRegularExpressionCaseInsensitive error:nil];
+    }
+    
+    return __parenthesisRegularExpression;
+}
+
+@interface EspressoViewController () <TTTAttributedLabelDelegate, UIActionSheetDelegate>
+
+@property (nonatomic, readonly, assign) TTTAttributedLabel *attributedLabel;
+
+@end
+
+@implementation EspressoViewController
+
+@synthesize espresso = _espresso;
+
+- (id)init {
+    if ((self = [super init])) {
+    }
+    return self;
+}
+
+#pragma mark - UIViewController
+
+- (TTTAttributedLabel *)attributedLabel {
+    return (TTTAttributedLabel *)[[self.view subviews] objectAtIndex:0];
+}
+
+- (void)loadView {
+    UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+    
+    TTTAttributedLabel *attributedLabel = [[TTTAttributedLabel alloc] initWithFrame:CGRectMake(10, 10, 80, 80)];
+    attributedLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [view addSubview:attributedLabel];
+    
+    self.view = view;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.title = NSLocalizedString(@"Espresso", nil);
+    
+    self.attributedLabel.delegate = self;
+    self.attributedLabel.font = [UIFont systemFontOfSize:kSummaryTextFontSize];
+    self.attributedLabel.textColor = [UIColor darkGrayColor];
+    self.attributedLabel.lineBreakMode = UILineBreakModeWordWrap;
+    self.attributedLabel.numberOfLines = 0;
+    self.attributedLabel.linkAttributes = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES] forKey:(NSString *)kCTUnderlineStyleAttributeName];
+    
+    self.attributedLabel.highlightedTextColor = [UIColor whiteColor];
+    self.attributedLabel.shadowColor = [UIColor colorWithWhite:0.87 alpha:1.0];
+    self.attributedLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
+    self.attributedLabel.verticalAlignment = TTTAttributedLabelVerticalAlignmentTop;
+    
+    [self.attributedLabel setText:self.espresso afterInheritingLabelAttributesAndConfiguringWithBlock:^NSMutableAttributedString *(NSMutableAttributedString *mutableAttributedString) {
+        NSRange stringRange = NSMakeRange(0, [mutableAttributedString length]);
+        
+        NSRegularExpression *regexp = NameRegularExpression();
+        NSRange nameRange = [regexp rangeOfFirstMatchInString:[mutableAttributedString string] options:0 range:stringRange];
+        UIFont *boldSystemFont = [UIFont boldSystemFontOfSize:kSummaryTextFontSize]; 
+        CTFontRef boldFont = CTFontCreateWithName((__bridge CFStringRef)boldSystemFont.fontName, boldSystemFont.pointSize, NULL);
+        if (boldFont) {
+            [mutableAttributedString removeAttribute:(NSString *)kCTFontAttributeName range:nameRange];
+            [mutableAttributedString addAttribute:(NSString *)kCTFontAttributeName value:(__bridge id)boldFont range:nameRange];
+            CFRelease(boldFont);
+        }
+        
+        [mutableAttributedString replaceCharactersInRange:nameRange withString:[[[mutableAttributedString string] substringWithRange:nameRange] uppercaseString]];
+        
+        regexp = ParenthesisRegularExpression();
+        [regexp enumerateMatchesInString:[mutableAttributedString string] options:0 range:stringRange usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {            
+            UIFont *italicSystemFont = [UIFont italicSystemFontOfSize:kSummaryTextFontSize];
+            CTFontRef italicFont = CTFontCreateWithName((__bridge CFStringRef)italicSystemFont.fontName, italicSystemFont.pointSize, NULL);
+            if (italicFont) {
+                [mutableAttributedString removeAttribute:(NSString *)kCTFontAttributeName range:result.range];
+                [mutableAttributedString addAttribute:(NSString *)kCTFontAttributeName value:(__bridge id)italicFont range:result.range];
+                CFRelease(italicFont);
+                
+                [mutableAttributedString removeAttribute:(NSString *)kCTForegroundColorAttributeName range:result.range];
+                [mutableAttributedString addAttribute:(NSString*)kCTForegroundColorAttributeName value:(id)[[UIColor grayColor] CGColor] range:result.range];
+            }
+        }];
+        
+        return mutableAttributedString;
+    }];
+    
+    NSRegularExpression *regexp = NameRegularExpression();
+    NSRange linkRange = [regexp rangeOfFirstMatchInString:self.espresso options:0 range:NSMakeRange(0, [self.espresso length])];
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"http://en.wikipedia.org/wiki/%@", [self.espresso substringWithRange:linkRange]]];
+    [self.attributedLabel addLinkToURL:url withRange:linkRange];
+}
+
+#pragma mark - TTTAttributedLabelDelegate
+
+- (void)attributedLabel:(TTTAttributedLabel *)label didSelectLinkWithURL:(NSURL *)url {
+    [[[UIActionSheet alloc] initWithTitle:[url absoluteString] delegate:self cancelButtonTitle:NSLocalizedString(@"Cancel", nil) destructiveButtonTitle:nil otherButtonTitles:NSLocalizedString(@"Open Link in Safari", nil), nil] showInView:self.view];
+}
+
+#pragma mark - UIActionSheetDelegate
+
+- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {
+    if (buttonIndex == actionSheet.cancelButtonIndex) {
+        return;
+    }
+    
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:actionSheet.title]];
+}
+
+@end

--- a/TTTAttributedLabelExample/TTTAttributedLabelExample/RootViewController.m
+++ b/TTTAttributedLabelExample/TTTAttributedLabelExample/RootViewController.m
@@ -23,6 +23,7 @@
 #import "RootViewController.h"
 
 #import "AttributedTableViewCell.h"
+#import "EspressoViewController.h"
 
 @implementation RootViewController
 @synthesize espressos = _espressos;
@@ -39,7 +40,6 @@
     return self;
 }
 
-
 #pragma mark - UIViewController
 
 - (void)viewDidLoad {
@@ -49,7 +49,7 @@
     [self.navigationController.navigationBar setTintColor:[UIColor darkGrayColor]];
 }
 
-#pragma mark - UITableViewDatasource
+#pragma mark - UITableViewDataSource
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return [self.espressos count];
@@ -65,6 +65,7 @@
     AttributedTableViewCell *cell = (AttributedTableViewCell *)[tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
         cell = [[AttributedTableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     }
     
     NSString *description = [self.espressos objectAtIndex:indexPath.row];
@@ -78,7 +79,11 @@
 #pragma mark - UITableViewDelegate
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    NSString *description = [self.espressos objectAtIndex:indexPath.row];
+    
+    EspressoViewController *viewController = [[EspressoViewController alloc] init];
+    viewController.espresso = description;
+    [self.navigationController pushViewController:viewController animated:YES];
 }
 
 #pragma mark - TTTAttributedLabelDelegate
@@ -89,7 +94,7 @@
 
 #pragma mark - UIActionSheetDelegate
 
--(void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {
+- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {
     if (buttonIndex == actionSheet.cancelButtonIndex) {
         return;
     }


### PR DESCRIPTION
I need to show active links in my app to improve usability. To that end, I adapted the work done by @dikbrouwer to show the active link appearance. Some things to note:
-  The example app runs on 4.3 and 5.1 exactly as I think you would expect it to. Specifically, you can scroll the table view when touching any part of the label, but table view cell selection can only occur outside of a link. As soon as you move your finger or actually tap the link, the link becomes inactive again.
- I extended the example app so that when you tap a cell, it pushes another view controller showing the TTTAttributedLabel without a UITableView. I found this useful when testing use case scenarios, prompting me to scrap my initial implementation and adopt a different one with better behavior.
- The solution is built using UIResponder touch methods. I initially used a UIGestureRecognizer subclass, but as I improved the active state behavior, the interaction between TTTAttributedLabel and the gesture recognizer quickly became unmanageable.

Let me know if there's anything I can do to improve this contribution. Thanks.
