### PR TITLE
Podspec file tweak

### DIFF
--- a/TTTAttributedLabel.podspec
+++ b/TTTAttributedLabel.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.authors = {'Mattt Thompson' => 'm@mattt.me'}
   s.homepage = 'https://github.com/mattt/TTTAttributedLabel/'
   s.summary = 'A drop-in replacement for UILabel that supports NSAttributedStrings.'
-  s.source = {:git => 'git://github.com/mattt/TTTAttributedLabel.git', :tag => '1.3.0'}
+  s.source = {:git => 'https://github.com/mattt/TTTAttributedLabel.git', :tag => '1.3.0'}
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   
   s.platform = :ios


### PR DESCRIPTION
Hi, I've added requires_arc flag to the podspec file, since TTTAttributedLabel now makes use of it. I also included a compiler flag they added in Specs repo, I guess it has been done for a reason. :)
