### PR TITLE
Small tweak ;)

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -293,12 +293,7 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
         return [NSArray array];
     }
     
-    NSMutableArray *mutableLinks = [NSMutableArray array];
-    [self.dataDetector enumerateMatchesInString:string options:0 range:range usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
-        [mutableLinks addObject:result];
-    }];
-    
-    return [NSArray arrayWithArray:mutableLinks];
+    return [self.dataDetector matchesInString:string options:0 range:range];
 }
 
 - (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result attributes:(NSDictionary *)attributes {


### PR DESCRIPTION
While perusing through the code, I noticed that in [`-detectedLinksInString:range:error:`](https://github.com/mattt/TTTAttributedLabel/blob/master/TTTAttributedLabel.m#L291) the usage of [`-[NSRegularExpression enumerateMatchesInString:options:range:withBlock:`]](https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSRegularExpression_Class/Reference/Reference.html#//apple_ref/doc/uid/TP40009708-CH1-SW10) to construct an array of [`NSTextCheckingResult`](https://developer.apple.com/library/ios/#documentation/AppKit/Reference/NSTextCheckingResult_Class/Reference/Reference.html) objects manually was not necessary, as there is another method defined in `NSRegularExpression` which does this for you: [`-matchesInString:options:range:`](https://developer.apple.com/library/ios/#documentation/Foundation/Reference/NSRegularExpression_Class/Reference/Reference.html#//apple_ref/occ/instm/NSRegularExpression/matchesInString:options:range:)

Sure, it's just a convenience method, but I think that this cleans up the code a bit, which is always a good thing. ;)

☺
