### PR TITLE
We don't want to write more CGPoints than we have allocated space for.

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -419,7 +419,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     NSUInteger idx = NSNotFound;
 
     CGPoint lineOrigins[numberOfLines];
-    CTFrameGetLineOrigins(frame, CFRangeMake(0, 0), lineOrigins);
+    CTFrameGetLineOrigins(frame, CFRangeMake(0, numberOfLines), lineOrigins);
 
     for (CFIndex lineIndex = 0; lineIndex < numberOfLines; lineIndex++) {
         CGPoint lineOrigin = lineOrigins[lineIndex];


### PR DESCRIPTION
If `CTFrameGetLineOrigins` is passed a range of `CFRangeMake(0, 0)`, this can have disastrous effects when  `CTFrameGetLines(frame) > numberOfLines`. The variable-length array overflows and destroys the stack, usually resulting in a crash.

Figured you guys might want this upstream. :)
