### PR TITLE
Active links don't always switch back to inactive on touch end

### DIFF
--- a/TTTAttributedLabel.m
+++ b/TTTAttributedLabel.m
@@ -904,51 +904,48 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
     if (self.activeLink) {
-        UITouch *touch = [touches anyObject];
-        if (self.activeLink == [self linkAtPoint:[touch locationInView:self]]) {
-            [self setLinkActive:NO withTextCheckingResult:self.activeLink];
-            
-            if (!self.delegate) {
-                return;
-            }
-            
-            NSTextCheckingResult *result = self.activeLink;
-            switch (result.resultType) {
-                case NSTextCheckingTypeLink:
-                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
-                        return;
-                    }
-                    break;
-                case NSTextCheckingTypeAddress:
-                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithAddress:result.addressComponents];
-                        return;
-                    }
-                    break;
-                case NSTextCheckingTypePhoneNumber:
-                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:result.phoneNumber];
-                        return;
-                    }
-                    break;
-                case NSTextCheckingTypeDate:
-                    if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithDate:result.date timeZone:result.timeZone duration:result.duration];
-                        return;
-                    } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithDate:result.date];
-                        return;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            
-            // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
-            if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
-            }
+        [self setLinkActive:NO withTextCheckingResult:self.activeLink];
+        
+        if (!self.delegate) {
+            return;
+        }
+        
+        NSTextCheckingResult *result = self.activeLink;
+        switch (result.resultType) {
+            case NSTextCheckingTypeLink:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypeAddress:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithAddress:result.addressComponents];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypePhoneNumber:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:result.phoneNumber];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypeDate:
+                if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithDate:result.date timeZone:result.timeZone duration:result.duration];
+                    return;
+                } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithDate:result.date];
+                    return;
+                }
+                break;
+            default:
+                break;
+        }
+        
+        // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
+        if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
+            [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
         }
     } else {
         [super touchesEnded:touches withEvent:event];


### PR DESCRIPTION
Active links don't always switch back to inactive in `touchesEnded:WithEvent:`. In my test I'm using HelveticaNeue-Medium size 40.0 with the only difference between active and inactive links being text color. Touching the bottom edge of a character in the linked text consistently reproduces the bug.

It seems that `[self linkAtPoint:[touch locationInView:self]]` is returning nil in this case. I added some logging in touch start, touch end, touch moved, and touch canceled, to see if the touch point matches the location of an active link. Here's my log:

```
2012-11-15 21:34:42.643 TTTLabelTest[6923:907] start: (85.000000, 251.000000)
2012-11-15 21:34:42.646 TTTLabelTest[6923:907] match
2012-11-15 21:34:42.722 TTTLabelTest[6923:907] end: (87.000000, 261.000000)
2012-11-15 21:34:42.725 TTTLabelTest[6923:907] no match 
```

It seems that there's some variance between the start and end points, without a move event fired in between.

Is the linkAtPoint: check necessary in touchesEnded? Shouldn't all links technically be inactive once a finger leaves the screen?
