### PR TITLE
Last line gets cut off for certain fonts

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -86,7 +86,7 @@ static inline NSDictionary * NSAttributedStringAttributesFromLabel(TTTAttributed
     
     CTTextAlignment alignment = CTTextAlignmentFromUITextAlignment(label.textAlignment);
     CGFloat lineSpacing = label.leading;
-    CGFloat lineSpacingAdjustment = label.font.lineHeight - label.font.ascender + label.font.descender;
+    CGFloat lineSpacingAdjustment = ceilf(label.font.lineHeight - label.font.ascender + label.font.descender);
     CGFloat lineHeightMultiple = label.lineHeightMultiple;
     CGFloat topMargin = label.textInsets.top;
     CGFloat bottomMargin = label.textInsets.bottom;


### PR DESCRIPTION
When using fonts in the HelveticNeue family, the last line of text is frequently cut off because `CTFramesetterSuggestFrameSizeWithConstraints` is suggesting the wrong height in `textRectForBounds:limitedToNumberOfLines:`

System font, size 15.0:
![System Font](http://i.imgur.com/3HPkR.png)
HelveticNeue, size 15.0:
![HelveticNeue](http://i.imgur.com/MhTlg.png)

To reproduce:

```
TTTAttributedLabel *label = [[TTTAttributedLabel alloc] initWithFrame:CGRectMake(0.0, 0.0, 225.0, 0.0)];
label.numberOfLines = 0;
label.lineBreakMode = NSLineBreakByWordWrapping;
label.font = [UIFont fontWithName:@"HelveticaNeue" size:15.0];  // cuts off the last line
// label.font = [UIFont systemFontOfSize:15.0];  // works properly
label.textColor = [UIColor darkGrayColor];
label.backgroundColor = [UIColor lightGrayColor];
[self.view addSubview:label];

label.text = @"Your friend Johnny Appleseed just posted 4 new photos near Brooklyn.";
CGSize labelSize = [label sizeThatFits:CGSizeMake(label.frame.size.width, CGFLOAT_MAX)];
label.frame = CGRectMake(0.0, 0.0, label.frame.size.width, labelSize.height);
```

It's interesting though because `CTFramesetterSuggestFrameSizeWithConstraints`suggests the correct height in `sizeThatFits:` seemingly because the height constraint there is CGFLOAT_MAX.

I'd assume there are similar issues with other fonts.
