### PR TITLE
Update TTTAttributedLabel/TTTAttributedLabel.m

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -587,8 +587,8 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
                     runBounds.size.width = CGRectGetWidth(lineBounds);
                 }
                 
-                CGRect rect = CGRectInset(CGRectInset(runBounds, -1.0f, -3.0f), lineWidth, lineWidth);
-                CGPathRef path = [[UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:cornerRadius] CGPath];
+                CGRect localRect = CGRectInset(CGRectInset(runBounds, -1.0f, -3.0f), lineWidth, lineWidth);
+                CGPathRef path = [[UIBezierPath bezierPathWithRoundedRect:localRect cornerRadius:cornerRadius] CGPath];
                 
                 CGContextSetLineJoin(c, kCGLineJoinRound);
                 


### PR DESCRIPTION
the local declaration of the variable `rect` is hiding the method parameter with the same name. Xcode is showing a warning when the compiler option `Hidden Local Variables` is set yo `Yes`
