### PR TITLE
Proper handling for touch events on links

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -964,6 +964,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 - (void)touchesEnded:(NSSet *)touches
            withEvent:(UIEvent *)event
 {
+	UITouch *touch = [touches anyObject];
+	self.activeLink = [self linkAtPoint:[touch locationInView:self]];
     if (self.activeLink) {
         [self setLinkActive:NO withTextCheckingResult:self.activeLink];
         


### PR DESCRIPTION
Currently, if the user touches down on a link and drags their finger outside of the link touchesEnded does not take into account that the link is no longer active and still fires off a touch event.

I have added "touch up inside" functionality for links. This fix ensures touch events are only handled if the users touches up inside the links and not outside the link (which should cancel any touch events).

To test with the Espressos demo project be sure to drag to the right from a link (so you're not scrolling).
