### PR TITLE
Vertical text cropping

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -803,20 +803,20 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     }
         
     CGRect textRect = bounds;
+    textRect.size.height = fmaxf(self.font.pointSize * 2.0f, bounds.size.height); // For vertical cropping
     
     // Adjust the text to be in the center vertically, if the text size is smaller than bounds
-    CGSize textSize = CTFramesetterSuggestFrameSizeWithConstraints(self.framesetter, CFRangeMake(0, [self.attributedText length]), NULL, bounds.size, NULL);
+    CGSize textSize = CTFramesetterSuggestFrameSizeWithConstraints(self.framesetter, CFRangeMake(0, [self.attributedText length]), NULL, textRect.size, NULL);
     textSize = CGSizeMake(ceilf(textSize.width), ceilf(textSize.height)); // Fix for iOS 4, CTFramesetterSuggestFrameSizeWithConstraints sometimes returns fractional sizes
     
     if (textSize.height < textRect.size.height) {
-        CGFloat heightChange = (textRect.size.height - textSize.height);
         CGFloat yOffset = 0.0f;
         switch (self.verticalAlignment) {
             case TTTAttributedLabelVerticalAlignmentCenter:
-                yOffset = floorf((textRect.size.height - textSize.height) / 2.0f);
+                yOffset = floorf((bounds.size.height - textSize.height) / 2.0f);
                 break;
             case TTTAttributedLabelVerticalAlignmentBottom:
-                yOffset = textRect.size.height - textSize.height;
+                yOffset = bounds.size.height - textSize.height;
                 break;
             case TTTAttributedLabelVerticalAlignmentTop:
             default:
@@ -824,7 +824,6 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         }
         
         textRect.origin.y += yOffset;
-        textRect.size = CGSizeMake(textRect.size.width, textRect.size.height - heightChange + yOffset);
     }
     
     return textRect;


### PR DESCRIPTION
If the label bounds are not high enough, `CTFramesetterSuggestFrameSizeWithConstraints` returns `CGSizeZero` and no text is rendered at all. By setting the text rect height to be twice the font point size, `CTFramesetterSuggestFrameSizeWithConstraints` doesn't return `CGSizeZero` thus the text is rendered cropped.

Legend:

> Black text = `UILabel`
> White text = `TTTAttributedLabel`
> Static = text set in the nib
> Dynamic = text set programmatically

Rendering before the vertical cropping patch:
![TTTAttributedLabel-original](https://f.cloud.github.com/assets/51363/50224/fd4a9b7c-5999-11e2-856c-2cfc9f8f142f.png)

Rendering after the vertical cropping patch:
![TTTAttributedLabel vertical-cropping](https://f.cloud.github.com/assets/51363/50225/fd4de980-5999-11e2-9361-f1023334cfa4.png)
