### PR TITLE
Add feature: custom truncation token string

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -168,6 +168,13 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
  */
 @property (nonatomic, assign) TTTAttributedLabelVerticalAlignment verticalAlignment;
 
+/**
+ The custom truncation token that appears at the end of the line. The value is nil by default and we'll use the Unicode horizontal ellipsis character code.
+ 
+ It only works when `lineBreakMode` value is `UILineBreakModeHeadTruncation`, `UILineBreakModeTailTruncation`, or `UILineBreakModeMiddleTruncation`
+ */
+@property (nonatomic, strong) NSAttributedString *truncationTokenString;
+
 ///----------------------------------
 /// @name Setting the Text Attributes
 ///----------------------------------

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -544,7 +544,7 @@ withTextCheckingResult:(NSTextCheckingResult *)result
                 // Get the attributes and use them to create the truncation token string
                 NSDictionary *tokenAttributes = [attributedString attributesAtIndex:truncationAttributePosition effectiveRange:NULL];
                 // \u2026 is the Unicode horizontal ellipsis character code
-                NSAttributedString *tokenString = [[NSAttributedString alloc] initWithString:@"\u2026" attributes:tokenAttributes];
+                NSAttributedString *tokenString = self.truncationTokenString ? : [[NSAttributedString alloc] initWithString:@"\u2026" attributes:tokenAttributes];
                 CTLineRef truncationToken = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)tokenString);
                 
                 // Append truncationToken to the string


### PR DESCRIPTION
Hi, I added a custom truncation token feature.

You can apply custom truncation token in the following situation:

> NSAttributedString is pretty rad. When it was ported into iOS 4 from Mac OS, iPhone developers everywhere rejoiced. Unfortunately, as of iOS 4 none of the standard controls in UIKit support it. Bummer.
> TTTAttributedLabel was created to be a drop-in replacement for UILabel, that provided a simple API to styling text with NSAttributedString while remaining performant. As a bonus, it also supports link embedding...[More](https://github.com/mattt/TTTAttributedLabel)

Here, the `...More` may be the custom truncation token string
