### PR TITLE
Set activeLink to nil on setText:

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -716,6 +716,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     }
     
     self.attributedText = text;
+    self.activeLink = nil;
 
     self.links = [NSArray array];
     if (self.dataDetectorTypes != UIDataDetectorTypeNone) {


### PR DESCRIPTION
This solves a bug I was experiencing. I am using a UISwipeGestureRecognizer to do some animations and switch the text in the TTTAttributedLabel during these animations. This was working fine except for when the swipe gesture would occur on top of a link (making it active while swiping). 

The label would actually get the correct text and size itself correctly based on the new text, but the drawn text wouldn't actually update and remain identical to the previous text. This simple fix ensures that the link is no longer active when setting the text on an already initialized label.
