### PR TITLE
Don't crash when value is nil

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -722,7 +722,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     self.activeLink = nil;
 
     self.links = [NSArray array];
-    if (self.dataDetectorTypes != UIDataDetectorTypeNone) {
+    if (self.attributedText && self.dataDetectorTypes != UIDataDetectorTypeNone) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             NSArray *results = [self.dataDetector matchesInString:[self.attributedText string] options:0 range:NSMakeRange(0, [self.attributedText length])];
             if ([results count] > 0 && [[self.attributedText string] isEqualToString:[text string]]) {


### PR DESCRIPTION
If the TTTAttributedLabel is set to nil and data detector types is not nil, then a crash happens in the block at line 727.

[NSDataDetector enumerateMatchesInString:options:range:usingBlock:]: nil argument' crash.
