### PR TITLE
Add corresponding `highlighted` properties for `shadowColor`, `shadowOffset` and `shadowRadius`

### DIFF
--- a/Example/AttributedTableViewCell.m
+++ b/Example/AttributedTableViewCell.m
@@ -81,6 +81,9 @@ static inline NSRegularExpression * ParenthesisRegularExpression() {
     self.summaryLabel.highlightedTextColor = [UIColor whiteColor];
     self.summaryLabel.shadowColor = [UIColor colorWithWhite:0.87 alpha:1.0];
     self.summaryLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
+    self.summaryLabel.highlightedShadowColor = [UIColor colorWithWhite:0.0f alpha:0.25f];
+    self.summaryLabel.highlightedShadowOffset = CGSizeMake(0.0f, -1.0f);
+    self.summaryLabel.highlightedShadowRadius = 1;
     self.summaryLabel.verticalAlignment = TTTAttributedLabelVerticalAlignmentTop;
 
     [self.contentView addSubview:self.summaryLabel];

--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -129,6 +129,19 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
  */
 @property (nonatomic, assign) CGFloat shadowRadius;
 
+/** 
+ The shadow blur radius for the label when the label's `highlighted` property is `YES`. A value of 0 indicates no blur, while larger values produce correspondingly larger blurring. This value must not be negative. The default value is 0.
+ */
+@property (nonatomic, assign) CGFloat highlightedShadowRadius;
+/** 
+ The shadow offset for the label when the label's `highlighted` property is `YES`. A size of {0, 0} indicates no offset, with positive values extending down and to the right. The default size is {0, 0}.
+ */
+@property (nonatomic, assign) CGSize highlightedShadowOffset;
+/** 
+ The shadow color for the label when the label's `highlighted` property is `YES`. The default value is `nil` (no shadow color).
+ */
+@property (nonatomic, strong) UIColor *highlightedShadowColor;
+
 ///--------------------------------------------
 /// @name Acccessing Paragraph Style Attributes
 ///--------------------------------------------

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -881,6 +881,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     // Second, trace the shadow before the actual text, if we have one
     if (self.shadowColor && !self.highlighted) {
         CGContextSetShadowWithColor(c, self.shadowOffset, self.shadowRadius, [self.shadowColor CGColor]);
+    } else if (self.highlightedShadowColor) {
+        CGContextSetShadowWithColor(c, self.highlightedShadowOffset, self.highlightedShadowRadius, [self.highlightedShadowColor CGColor]);
     }
     
     // Finally, draw the text or highlighted text itself (on top of the shadow, if there is one)


### PR DESCRIPTION
These additions are [not in line with the documentation](https://github.com/mattt/TTTAttributedLabel/issues/168), but the existing `shadowRadius` property is not either so I'm not sure if this is an appropriate pull request. 

The existing behavior is that if the label is `highlighted` to not add any shadow. This contradicts regular `NSString` drawing behavior, which is to use the same `shadowOffset` and `shadowColor` whether highlighted or not.
