### PR TITLE
Fix a crash and handling of adjusting font size

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -157,8 +157,9 @@ static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttribu
                 pointSize = CTFontGetSize(ctFont);
             }
             [mutableAttributedString removeAttribute:(NSString *)kCTFontAttributeName range:range];
-            font = [UIFont fontWithName:fontName size:floorf(pointSize * scale)];
-            [mutableAttributedString addAttribute:(NSString *)kCTFontAttributeName value:font range:range];
+            CTFontRef fontRef = CTFontCreateWithName((__bridge CFStringRef)fontName, floorf(pointSize * scale), NULL);
+            [mutableAttributedString addAttribute:(NSString *)kCTFontAttributeName value:(__bridge id)fontRef range:range];
+            CFRelease(fontRef);
         }
     }];
     


### PR DESCRIPTION
This request includes 3 fixes, all around adjusting font size:
- Adjusting font size doesn't work with numberOfLines > 1
  When setting number of lines to be greater then 1, and trying to constraint it to specific width, TTTAttributedLabel tries to calculate the ratio in which to 
  adjust the font size. I think the comparsion is wrong for multiple lines.  
- When label font size is scaled, app will crash as NSAttributedStringByScalingFontSize expect font attribute to be UIFont, thought it can be CTFont.
- When label font size is scaled, other attributed except font are being removed.

I was't sure if you prefer separate pull requests, so I hope it's ok that I aggregated them into one.
