### PR TITLE
Explicitly synthesizing properties for xcode 4.3.2 (LLVM 3.2) compilers

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -221,6 +221,9 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
 @synthesize verticalAlignment = _verticalAlignment;
 @synthesize truncationTokenString = _truncationTokenString;
 @synthesize activeLink = _activeLink;
+@synthesize highlightedShadowRadius = _highlightedShadowRadius;
+@synthesize highlightedShadowOffset = _highlightedShadowOffset;
+@synthesize highlightedShadowColor = _highlightedShadowColor;
 
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];


### PR DESCRIPTION
The compiler in Xcode 4.3.2 uses LLVM 3.2 compiler and allows for auto synthesize of properties but at runtime the code fails and throws a "doesNotResponseToSelector" error.  Instead of using implicit property synthesis it is better in this case to make it explicit to support earlier versions of the compiler and Xcode.

I am using this on an internal project where I do not have access to updating the build server, thus I needed to make this change so I could deploy the app in the enterprise.
