### PR TITLE
Leave the CGContextRef as we found it

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -924,6 +924,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     }
     
     CGContextRef c = UIGraphicsGetCurrentContext();
+    CGContextSaveGState(c);
     CGContextSetTextMatrix(c, CGAffineTransformIdentity);
 
     // Inverts the CTM to match iOS coordinates (otherwise text draws upside-down; Mac OS's system is different)
@@ -963,6 +964,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     if (originalAttributedText) {
         self.text = originalAttributedText;
     }
+    CGContextRestoreGState(c);
 }
 
 #pragma mark - UIView


### PR DESCRIPTION
Avoid potential compounding transforms, causing text to draw out of frame.  This fixes the issue detailed in https://github.com/mattt/TTTAttributedLabel/issues/206

Definitely an unusual use case, but it was a big performance win for me to be able to render a label to a bitmap context asynchronously.  
