### PR TITLE
Fix for right margin bug with textInsets

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -113,7 +113,7 @@ static inline NSDictionary * NSAttributedStringAttributesFromLabel(TTTAttributed
         CGFloat topMargin = label.textInsets.top;
         CGFloat bottomMargin = label.textInsets.bottom;
         CGFloat leftMargin = label.textInsets.left;
-        CGFloat rightMargin = label.textInsets.right;
+        CGFloat rightMargin = -label.textInsets.right;
         CGFloat firstLineIndent = label.firstLineIndent + leftMargin;
 
         CTLineBreakMode lineBreakMode;


### PR DESCRIPTION
Corrected textInsets right inset to be an inset from right margin rather than the left margin which is default.

Fixes #225.
