### PR TITLE
bugfix: offscreen rendering

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -312,6 +312,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     _attributedText = [text copy];
     
     [self setNeedsFramesetter];
+    [self setNeedsDisplay];
 }
 
 - (void)setNeedsFramesetter {


### PR DESCRIPTION
fixed: if the label is rendered offscreen it won't update it's contents on setAttributedString without setNeedsDiplay
