### PR TITLE
Better AutoLayout intrinisicContentSize

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1005,7 +1005,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 }
 
 - (CGSize)intrinsicContentSize {
-    return [self sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
+    // There's an implicit width from the original UILabel implementation
+    return [self sizeThatFits:[super intrinsicContentSize]];
 }
 
 #pragma mark - UIResponder


### PR DESCRIPTION
There's an implicit width from the original implementation of the UILabel, we should bring that to our -[TTTAttributedLabel sizeThatFits:]

So now the label layouts more closely to the original UILabel.

Before:
![old](https://f.cloud.github.com/assets/852375/553602/da29020e-c38a-11e2-8ca7-86e3ed4217d9.png)

After:
![fixed](https://f.cloud.github.com/assets/852375/553604/e20272e4-c38a-11e2-9754-2f497cf74583.png)
