### PR TITLE
Add IBOutlet id <TTTAttributedLabelDelegate> delegate

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -94,7 +94,7 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
  
  @discussion A `TTTAttributedLabel` delegate responds to messages sent by tapping on links in the label. You can use the delegate to respond to links referencing a URL, address, phone number, date, or date with a specified time zone and duration.
  */
-@property (nonatomic, unsafe_unretained) id <TTTAttributedLabelDelegate> delegate;
+@property (nonatomic, unsafe_unretained) IBOutlet id <TTTAttributedLabelDelegate> delegate;
 
 ///--------------------------------------------
 /// @name Detecting, Accessing, & Styling Links


### PR DESCRIPTION
So we can link delegate inside interface builder.
