### PR TITLE
Change truncationTokenString to truncationTokenAttributeString

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -190,7 +190,7 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
 
  @discussion When truncation is enabled for the label, by setting `lineBreakMode` to either `UILineBreakModeHeadTruncation`, `UILineBreakModeTailTruncation`, or `UILineBreakModeMiddleTruncation`, the token used to terminate the truncated line will be `truncationTokenString` if defined, otherwise the Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026).
  */
-@property (nonatomic, strong) NSString *truncationTokenString;
+@property (nonatomic, strong) NSAttributedString *truncationTokenAttributedString;
 
 ///----------------------------------
 /// @name Setting the Text Attributes

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -220,7 +220,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
 @synthesize firstLineIndent = _firstLineIndent;
 @synthesize textInsets = _textInsets;
 @synthesize verticalAlignment = _verticalAlignment;
-@synthesize truncationTokenString = _truncationTokenString;
+@synthesize truncationTokenAttributedString = _truncationTokenAttributedString;
 @synthesize activeLink = _activeLink;
 
 - (id)initWithFrame:(CGRect)frame {
@@ -544,13 +544,11 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
                 }
                 
                 // Get the attributes and use them to create the truncation token string
-                NSDictionary *tokenAttributes = [attributedString attributesAtIndex:truncationAttributePosition effectiveRange:NULL];
-                NSString *truncationTokenString = self.truncationTokenString;
-                if (!truncationTokenString) {
-                    truncationTokenString = @"\u2026"; // Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026)
+                NSAttributedString *attributedTokenString = self.truncationTokenAttributedString;
+                if (!attributedTokenString) {
+                    attributedTokenString = [[NSAttributedString alloc] initWithString:@"\u2026"]; // Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026)
                 }
 
-                NSAttributedString *attributedTokenString = [[NSAttributedString alloc] initWithString:truncationTokenString attributes:tokenAttributes];
                 CTLineRef truncationToken = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)attributedTokenString);
                 
                 // Append truncationToken to the string
@@ -1108,7 +1106,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     [coder encodeFloat:self.lineHeightMultiple forKey:@"lineHeightMultiple"];
     [coder encodeUIEdgeInsets:self.textInsets forKey:@"textInsets"];
     [coder encodeInteger:self.verticalAlignment forKey:@"verticalAlignment"];
-    [coder encodeObject:self.truncationTokenString forKey:@"truncationTokenString"];
+    [coder encodeObject:self.truncationTokenAttributedString forKey:@"truncationTokenAttributedString"];
     [coder encodeObject:self.attributedText forKey:@"attributedText"];
 }
 
@@ -1175,7 +1173,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     }
 
     if ([coder containsValueForKey:@"truncationTokenString"]) {
-        self.truncationTokenString = [coder decodeObjectForKey:@"truncationTokenString"];
+        self.truncationTokenAttributedString = [coder decodeObjectForKey:@"truncationTokenAttributedString"];
     }
 
     if ([coder containsValueForKey:@"attributedText"]) {


### PR DESCRIPTION
In my project I need to add underline with truncation string, 
so i just changed truncationTokenString to truncationTokenAttributeString.

But there is a inconvenience that truncationTokenAttributeString does not inherit attributes.

I think it can resolve by adding boolean property such as tokenShouldInheritAttribute.

Thanks
Han
