### PR TITLE
Fix Links Not Taking adjustsFontSizeToFitWidth into Account

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1004,7 +1004,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         
         // If we adjusted the font size, set it back to its original size
         if (originalAttributedText) {
-            self.attributedText = originalAttributedText;
+            // Use ivar directly to avoid clearing out framesetter and renderedAttributedText
+            _attributedText = originalAttributedText;
         }
     } CGContextRestoreGState(c);
 }


### PR DESCRIPTION
It looks like at some point #37 resurfaced. The set of `attributedText` at the end of `drawTextInRect:` resets the `framesetter` and `renderedAttributedText` properties, the former of which is used by `characterIndexAtPoint:` to determine if a tapped point is inside a link.

Using the ivar directly to bypass the setter is maybe an ugly solution, but it's the simplest thing I could see to fix this issue.
