### PR TITLE
Add support for long-pressing links

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -315,6 +315,17 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 - (void)addLinkToTransitInformation:(NSDictionary *)components
                           withRange:(NSRange)range;
 
+
+/**
+ Returns a link found at a given point, or `nil` if none is found.
+ 
+ @param p A point in the label's coordinate system.
+ 
+ @discussion This method is useful for complex view hierarchies.  It can be used, for example, when implementing custom gesture recognizers, or for overriding `hitTest:withEvent:` to determine which view should handle a touch event.
+ */
+
+- (NSTextCheckingResult *)linkAtPoint:(CGPoint)p;
+
 @end
 
 /**
@@ -395,5 +406,89 @@ didSelectLinkWithTransitInformation:(NSDictionary *)components;
  */
 - (void)attributedLabel:(TTTAttributedLabel *)label
 didSelectLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
+
+///---------------------------------
+/// @name Responding to Long Presses
+///---------------------------------
+
+/**
+ Tells the delegate that the user did long press a link to a URL.
+ 
+ @param label The label whose link was long pressed.
+ @param url The URL for the link.
+ */
+- (void)attributedLabel:(TTTAttributedLabel *)label
+didLongPressLinkWithURL:(NSURL *)url
+                atPoint:(CGPoint)point;
+
+/**
+ Tells the delegate that the user did long press a link to an address.
+ 
+ @param label The label whose link was long pressed.
+ @param addressComponents The components of the address for the link.
+ */
+- (void)attributedLabel:(TTTAttributedLabel *)label
+didLongPressLinkWithAddress:(NSDictionary *)addressComponents
+                atPoint:(CGPoint)point;
+
+/**
+ Tells the delegate that the user did long press a link to a phone number.
+ 
+ @param label The label whose link was long pressed.
+ @param phoneNumber The phone number for the link.
+ */
+- (void)attributedLabel:(TTTAttributedLabel *)label
+didLongPressLinkWithPhoneNumber:(NSString *)phoneNumber
+                atPoint:(CGPoint)point;
+
+
+/**
+ Tells the delegate that the user did long press a link to a date.
+ 
+ @param label The label whose link was long pressed.
+ @param date The date for the selected link.
+ */
+- (void)attributedLabel:(TTTAttributedLabel *)label
+  didLongPressLinkWithDate:(NSDate *)date
+                atPoint:(CGPoint)point;
+
+
+/**
+ Tells the delegate that the user did long press a link to a date with a time zone and duration.
+ 
+ @param label The label whose link was long pressed.
+ @param date The date for the link.
+ @param timeZone The time zone of the date for the link.
+ @param duration The duration, in seconds from the date for the link.
+ */
+- (void)attributedLabel:(TTTAttributedLabel *)label
+  didLongPressLinkWithDate:(NSDate *)date
+               timeZone:(NSTimeZone *)timeZone
+               duration:(NSTimeInterval)duration
+                atPoint:(CGPoint)point;
+
+
+/**
+ Tells the delegate that the user did long press a link to transit information
+ 
+ @param label The label whose link was long pressed.
+ @param components A dictionary containing the transit components. The currently supported keys are `NSTextCheckingAirlineKey` and `NSTextCheckingFlightKey`.
+ */
+- (void)attributedLabel:(TTTAttributedLabel *)label
+didLongPressLinkWithTransitInformation:(NSDictionary *)components
+                atPoint:(CGPoint)point;
+
+/**
+ Tells the delegate that the user did long press a link to a text checking result.
+ 
+ @discussion Similar to `-attributedLabel:didSelectLinkWithTextCheckingResult:`, this method is called if a link is long pressed and the delegate does not implement the method corresponding to this type of link.
+ 
+ @param label The label whose link was long pressed.
+ @param result The custom text checking result.
+ */
+- (void)attributedLabel:(TTTAttributedLabel *)label
+didLongPressLinkWithTextCheckingResult:(NSTextCheckingResult *)result
+                atPoint:(CGPoint)point;
+
 
 @end

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -33,6 +33,11 @@ NSString * const kTTTBackgroundStrokeColorAttributeName = @"TTTBackgroundStrokeC
 NSString * const kTTTBackgroundLineWidthAttributeName = @"TTTBackgroundLineWidth";
 NSString * const kTTTBackgroundCornerRadiusAttributeName = @"TTTBackgroundCornerRadius";
 
+static const NSTimeInterval kLongPressTimeInterval = 0.5;
+static const CGFloat kLongPressGutter = 22;
+
+static inline CTTextAlignment CTTextAlignmentFromUITextAlignment(UITextAlignment alignment) {
+	switch (alignment) {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
 typedef NSTextAlignment TTTTextAlignment;
 typedef NSLineBreakMode TTTLineBreakMode;
@@ -224,6 +229,10 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
 @property (readwrite, nonatomic, strong) NSDataDetector *dataDetector;
 @property (readwrite, nonatomic, strong) NSArray *links;
 @property (readwrite, nonatomic, strong) NSTextCheckingResult *activeLink;
+
+@property (nonatomic, strong) NSTimer* longPressTimer;
+@property (nonatomic, assign) CGPoint touchPoint;
+
 @end
 
 @implementation TTTAttributedLabel {
@@ -292,6 +301,8 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
 }
 
 - (void)dealloc {
+    [_longPressTimer invalidate];
+    
     if (_framesetter) CFRelease(_framesetter);
     if (_highlightFramesetter) CFRelease(_highlightFramesetter);
 }
@@ -382,6 +393,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     
     if (self.enabledTextCheckingTypes) {
         self.dataDetector = [NSDataDetector dataDetectorWithTypes:self.enabledTextCheckingTypes error:nil];
+        self.text = self.text;
     } else {
         self.dataDetector = nil;
     }
@@ -872,6 +884,13 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
         [self setNeedsDisplay];
     }
+    
+    [self.longPressTimer invalidate];
+    self.longPressTimer = nil;
+
+    if (_activeLink) {
+        self.longPressTimer = [NSTimer scheduledTimerWithTimeInterval:kLongPressTimeInterval target:self selector:@selector(longPressTimerDidFire:) userInfo:nil repeats:NO];
+    }
 }
 
 #pragma mark - UILabel
@@ -1051,6 +1070,58 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     return [self sizeThatFits:[super intrinsicContentSize]];
 }
 
+#pragma mark - NSTimer
+
+- (void)longPressTimerDidFire:(NSTimer *)timer {
+    if (self.activeLink) {
+        NSTextCheckingResult *result = self.activeLink;
+        self.activeLink = nil;
+        
+        switch (result.resultType) {
+            case NSTextCheckingTypeLink:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithURL:atPoint:)]) {
+                    [self.delegate attributedLabel:self didLongPressLinkWithURL:result.URL atPoint:self.touchPoint];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypeAddress:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithAddress:atPoint:)]) {
+                    [self.delegate attributedLabel:self didLongPressLinkWithAddress:result.addressComponents atPoint:self.touchPoint];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypePhoneNumber:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithPhoneNumber:)]) {
+                    [self.delegate attributedLabel:self didLongPressLinkWithPhoneNumber:result.phoneNumber atPoint:self.touchPoint];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypeDate:
+                if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithDate:timeZone:duration:atPoint:)]) {
+                    [self.delegate attributedLabel:self didLongPressLinkWithDate:result.date timeZone:result.timeZone duration:result.duration atPoint:self.touchPoint];
+                    return;
+                } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithDate:)]) {
+                    [self.delegate attributedLabel:self didLongPressLinkWithDate:result.date atPoint:self.touchPoint];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypeTransitInformation:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithTransitInformation:atPoint:)]) {
+                    [self.delegate attributedLabel:self didLongPressLinkWithTransitInformation:result.components atPoint:self.touchPoint];
+                    return;
+                }
+            default:
+                break;
+        }
+        
+        // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
+        if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithTextCheckingResult:atPoint:)]) {
+            [self.delegate attributedLabel:self didLongPressLinkWithTextCheckingResult:result atPoint:self.touchPoint];
+        }
+    }
+}
+
+
 #pragma mark - UIResponder
 
 - (BOOL)canBecomeFirstResponder {
@@ -1068,22 +1139,39 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 {
     UITouch *touch = [touches anyObject];
     
-    self.activeLink = [self linkAtPoint:[touch locationInView:self]];
-        
+    self.touchPoint = [touch locationInView:self];
+    self.activeLink = [self linkAtPoint:self.touchPoint];
+
     if (!self.activeLink) {
         [super touchesBegan:touches withEvent:event];
     }
 }
 
+/*
+
+ */
 - (void)touchesMoved:(NSSet *)touches
            withEvent:(UIEvent *)event
 {
     if (self.activeLink) {
         UITouch *touch = [touches anyObject];
-        
-        if (self.activeLink != [self linkAtPoint:[touch locationInView:self]]) {
+        CGPoint point = [touch locationInView:self];
+
+        if (self.activeLink != [self linkAtPoint:point]) {
             self.activeLink = nil;
         }
+        
+        // Restart the the timer if the finger moves too far
+        if (fabsf(self.touchPoint.x - point.x) >= kLongPressGutter
+            || fabsf(self.touchPoint.y - point.y) >= kLongPressGutter) {
+            [self.longPressTimer invalidate];
+            self.longPressTimer = nil;
+            if (self.activeLink) {
+                self.longPressTimer = [NSTimer scheduledTimerWithTimeInterval:kLongPressTimeInterval target:self selector:@selector(longPressTimerDidFire:) userInfo:nil repeats:NO];
+                self.touchPoint = point;
+            }
+        }
+        
     } else {
         [super touchesMoved:touches withEvent:event];
     }


### PR DESCRIPTION
This pull request
- adds delegate callbacks for handling long-pressing on a URL (for example, to display an action sheet with secondary options)
- exposes the `linkAtPoint:` instance method, to make it easier to use TTTAttributedLabel in complex view hierarchies
- updates links if data detectors are changed after text is set 
