### PR TITLE
Fix static analyzer warning

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -353,7 +353,9 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
         @synchronized(self) {
             CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)self.renderedAttributedText);
             [self setFramesetter:framesetter];
-            CFRelease(framesetter);
+            if (framesetter) {
+                CFRelease(framesetter);
+            }
             [self setHighlightFramesetter:nil];
             _needsFramesetter = NO;
         }


### PR DESCRIPTION
framesetter could be nil (this warning may only occur in Xcode 4)
