### PR TITLE
Protect self.links for multiple additions of links.

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -463,6 +463,8 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
 - (void)addLinksWithTextCheckingResults:(NSArray *)results
                              attributes:(NSDictionary *)attributes
 {
+    NSArray *links = self.links;
+
     if (attributes) {
         NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
         for (NSTextCheckingResult *result in results) {
@@ -471,8 +473,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
         self.attributedText = mutableAttributedString;
         [self setNeedsDisplay];
     }
-    
-    self.links = [self.links arrayByAddingObjectsFromArray:results];
+    self.links = [links arrayByAddingObjectsFromArray:results];
 }
 
 - (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result {


### PR DESCRIPTION
When calling `-addLinkToURL:withRange:` multiple times, only the last add
is maintained. The underlaying cause is that `self.links` array is reset
when `self.attributedText` is set in the method's `if (attributes)` body.
The alternative fix was to protect the `self.links` property in the
`-setAttributedText:` method with the following: 

```
self.links = self.links ?: [NSArray array];
```

I felt the guard and replace strategy was less invasive.

Anon,
Andrew
