### PR TITLE
Add functionality for specifying an NSAttributedString to use for the truncation token

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -141,6 +141,16 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
  */
 @property (nonatomic, strong) NSDictionary *inactiveLinkAttributes;
 
+/**
+ The amount to inset the background of a link default is -1.
+ */
+@property (nonatomic, assign) CGFloat linkBackgroundInsetDX;
+
+/**
+ The amount to inset the background of a link default is 0.
+ */
+@property (nonatomic, assign) CGFloat linkBackgroundInsetDY;
+
 ///---------------------------------------
 /// @name Acccessing Text Style Attributes
 ///---------------------------------------
@@ -373,6 +383,15 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  */
 - (void)addLinkToTransitInformation:(NSDictionary *)components
                           withRange:(NSRange)range;
+
+/**
+ Returns YES if a NSTextCheckingResult is found at the give point.
+ 
+ @discussion This can be used together with UITapGestureRecognizer to improve the tapping on UIViews and UICollectionViewCells.
+ 
+ @param point The point inside the label to test at.
+ */
+- (BOOL)containslinkAtPoint:(CGPoint)p;
 
 @end
 

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -369,6 +369,9 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     self.lineHeightMultiple = 1.0f;
 
     self.links = [NSArray array];
+    
+    self.linkBackgroundInsetDX = -1.0f;
+    self.linkBackgroundInsetDY = 0.0f;
 
     NSMutableDictionary *mutableLinkAttributes = [NSMutableDictionary dictionary];
     [mutableLinkAttributes setObject:[NSNumber numberWithBool:YES] forKey:(NSString *)kCTUnderlineStyleAttributeName];
@@ -642,6 +645,12 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     return [self linkAtCharacterIndex:idx];
 }
 
+- (BOOL)containslinkAtPoint:(CGPoint)p {
+    CFIndex idx = [self characterIndexAtPoint:p];
+    
+    return ([self linkAtCharacterIndex:idx] != nil);
+}
+
 - (CFIndex)characterIndexAtPoint:(CGPoint)p {
     if (!CGRectContainsPoint(self.bounds, p)) {
         return NSNotFound;
@@ -836,6 +845,14 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                 CGContextSetTextPosition(c, penOffset, lineOrigin.y - descent - self.font.descender);
 
                 CTLineDraw(truncatedLine, c);
+                
+                NSRange linkRange;
+                if ([attributedTokenString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange]) {
+                    NSRange tokenRange = [truncationString.string rangeOfString:attributedTokenString.string];
+                    NSRange tokenLinkRange = NSMakeRange((NSUInteger)(lastLineRange.location+lastLineRange.length)-tokenRange.length, (NSUInteger)tokenRange.length);
+                    
+                    [self addLinkToURL:[attributedTokenString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange] withRange:tokenLinkRange];
+                }
 
                 CFRelease(truncatedLine);
                 CFRelease(truncationLine);
@@ -919,7 +936,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                     runBounds.size.width = CGRectGetWidth(lineBounds);
                 }
 
-                CGPathRef path = [[UIBezierPath bezierPathWithRoundedRect:CGRectInset(CGRectInset(runBounds, -1.0f, 0.0f), lineWidth, lineWidth) cornerRadius:cornerRadius] CGPath];
+                CGPathRef path = [[UIBezierPath bezierPathWithRoundedRect:CGRectInset(CGRectInset(runBounds, self.linkBackgroundInsetDX, self.linkBackgroundInsetDY), lineWidth, lineWidth) cornerRadius:cornerRadius] CGPath];
 
                 CGContextSetLineJoin(c, kCGLineJoinRound);
 
@@ -1537,6 +1554,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     [coder encodeUIEdgeInsets:self.textInsets forKey:NSStringFromSelector(@selector(textInsets))];
     [coder encodeInteger:self.verticalAlignment forKey:NSStringFromSelector(@selector(verticalAlignment))];
     [coder encodeObject:self.truncationTokenString forKey:NSStringFromSelector(@selector(truncationTokenString))];
+    [coder encodeObject:@(self.linkBackgroundInsetDX) forKey:NSStringFromSelector(@selector(linkBackgroundInsetDX))];
+    [coder encodeObject:@(self.linkBackgroundInsetDY) forKey:NSStringFromSelector(@selector(linkBackgroundInsetDY))];
     [coder encodeObject:self.attributedText forKey:NSStringFromSelector(@selector(attributedText))];
     [coder encodeObject:self.text forKey:NSStringFromSelector(@selector(text))];
 }
@@ -1621,6 +1640,14 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
     if ([coder containsValueForKey:NSStringFromSelector(@selector(truncationTokenString))]) {
         self.truncationTokenString = [coder decodeObjectForKey:NSStringFromSelector(@selector(truncationTokenString))];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(linkBackgroundInsetDX))]) {
+        self.linkBackgroundInsetDX = [[coder decodeObjectForKey:NSStringFromSelector(@selector(linkBackgroundInsetDX))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(linkBackgroundInsetDY))]) {
+        self.linkBackgroundInsetDY = [[coder decodeObjectForKey:NSStringFromSelector(@selector(linkBackgroundInsetDY))] floatValue];
     }
 
     if ([coder containsValueForKey:NSStringFromSelector(@selector(attributedText))]) {


### PR DESCRIPTION
Add functionality for specifying an NSAttributedString to use for the truncation token with a new property: `truncationTokenAttributedString`. This allows for a bit more customization of the truncation token, such as inclusion of different fonts, colours or anything else you would do with an NSAttributedString.

For example:

![screen shot 2013-12-19 at 4 53 24 pm](https://f.cloud.github.com/assets/708741/1786645/d569ba4c-68f8-11e3-9567-94939ddcb4c8.png)
