### PR TITLE
Add long press gesture support

### DIFF
--- a/Example/DetailViewController.m
+++ b/Example/DetailViewController.m
@@ -142,7 +142,11 @@ static inline NSRegularExpression * ParenthesisRegularExpression() {
 - (void)attributedLabel:(__unused TTTAttributedLabel *)label
    didSelectLinkWithURL:(NSURL *)url
 {
-    [[[UIActionSheet alloc] initWithTitle:[url absoluteString] delegate:self cancelButtonTitle:NSLocalizedString(@"Cancel", nil) destructiveButtonTitle:nil otherButtonTitles:NSLocalizedString(@"Open Link in Safari", nil), nil] showInView:self.view];
+    if (label.selectionState == TTTAttributedLabelSelectionStateLongPress) {
+        [[[UIActionSheet alloc] initWithTitle:[url absoluteString] delegate:self cancelButtonTitle:NSLocalizedString(@"Cancel", nil) destructiveButtonTitle:nil otherButtonTitles:NSLocalizedString(@"Open Link in Safari", nil), nil] showInView:self.view];
+    } else {
+        [[UIApplication sharedApplication] openURL:url];
+    }
 }
 
 #pragma mark - UIActionSheetDelegate

--- a/Example/RootViewController.m
+++ b/Example/RootViewController.m
@@ -95,7 +95,11 @@ didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 
 - (void)attributedLabel:(__unused TTTAttributedLabel *)label
    didSelectLinkWithURL:(NSURL *)url {
-    [[[UIActionSheet alloc] initWithTitle:[url absoluteString] delegate:self cancelButtonTitle:NSLocalizedString(@"Cancel", nil) destructiveButtonTitle:nil otherButtonTitles:NSLocalizedString(@"Open Link in Safari", nil), nil] showInView:self.view];
+    if (label.selectionState == TTTAttributedLabelSelectionStateLongPress) {
+        [[[UIActionSheet alloc] initWithTitle:[url absoluteString] delegate:self cancelButtonTitle:NSLocalizedString(@"Cancel", nil) destructiveButtonTitle:nil otherButtonTitles:NSLocalizedString(@"Open Link in Safari", nil), nil] showInView:self.view];
+    } else {
+        [[UIApplication sharedApplication] openURL:url];
+    }
 }
 
 #pragma mark - UIActionSheetDelegate

--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -32,6 +32,12 @@ typedef enum {
     TTTAttributedLabelVerticalAlignmentBottom   = 2,
 } TTTAttributedLabelVerticalAlignment;
 
+
+typedef enum {
+    TTTAttributedLabelSelectionStateTouchUp      = 0,
+    TTTAttributedLabelSelectionStateLongPress    = 1,
+} TTTAttributedLabelSelectionState;
+
 /**
  Determines whether the text to which this attribute applies has a strikeout drawn through itself.
  */
@@ -211,6 +217,19 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
  */
 @property (nonatomic, strong) NSDictionary *truncationTokenStringAttributes;
 
+///---------------------------------
+/// @name Long Press Gesture support
+///---------------------------------
+
+/**
+ The interval that activates the long press gesture. `0.65` by default, set `0` to disable.
+ */
+@property (nonatomic, assign) NSTimeInterval longPressInterval;
+
+/**
+ The selection state determines whether the user activates by tap/long press gesture.
+ */
+@property (nonatomic, readonly) TTTAttributedLabelSelectionState selectionState;
 
 ///--------------------------------------------
 /// @name Calculating Size of Attributed String

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -312,6 +312,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 @property (readwrite, nonatomic, strong) NSDataDetector *dataDetector;
 @property (readwrite, nonatomic, strong) NSArray *links;
 @property (readwrite, nonatomic, strong) NSTextCheckingResult *activeLink;
+@property (readwrite, nonatomic) TTTAttributedLabelSelectionState selectionState;
 @end
 
 @implementation TTTAttributedLabel {
@@ -336,6 +337,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 }
 
 - (void)commonInit {
+    self.longPressInterval = 0.65;
     self.userInteractionEnabled = YES;
     self.multipleTouchEnabled = NO;
         
@@ -386,6 +388,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     if (_highlightFramesetter) {
         CFRelease(_highlightFramesetter);
     }
+
+    [self cancelLongPress];
 }
 
 #pragma mark -
@@ -1189,7 +1193,11 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     UITouch *touch = [touches anyObject];
     
     self.activeLink = [self linkAtPoint:[touch locationInView:self]];
-        
+
+    if (self.longPressInterval > 0) {
+        [self performSelector:@selector(handleLongPressActivated) withObject:nil afterDelay:self.longPressInterval];
+    }
+
     if (!self.activeLink) {
         [super touchesBegan:touches withEvent:event];
     }
@@ -1212,6 +1220,30 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 - (void)touchesEnded:(NSSet *)touches
            withEvent:(UIEvent *)event
 {
+    [self cancelLongPress];
+    self.selectionState = TTTAttributedLabelSelectionStateTouchUp;
+
+    if (self.activeLink) {
+        [self performActionWithActiveLink];
+    } else {
+        [super touchesEnded:touches withEvent:event];
+    }
+}
+
+- (void)touchesCancelled:(NSSet *)touches
+               withEvent:(UIEvent *)event
+{
+    if (self.activeLink) {
+        self.activeLink = nil;
+    } else {
+        [super touchesCancelled:touches withEvent:event];
+    }
+}
+
+#pragma mark - Long Press
+
+- (void)performActionWithActiveLink {
+
     if (self.activeLink) {
         NSTextCheckingResult *result = self.activeLink;
         self.activeLink = nil;
@@ -1252,24 +1284,22 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
             default:
                 break;
         }
-        
+
         // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
         if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
             [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
         }
-    } else {
-        [super touchesEnded:touches withEvent:event];
+
     }
 }
 
-- (void)touchesCancelled:(NSSet *)touches
-               withEvent:(UIEvent *)event
-{
-    if (self.activeLink) {
-        self.activeLink = nil;
-    } else {
-        [super touchesCancelled:touches withEvent:event];
-    }
+- (void)cancelLongPress {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(handleLongPressActivated) object:nil];
+}
+
+- (void)handleLongPressActivated {
+    self.selectionState = TTTAttributedLabelSelectionStateLongPress;
+    [self performActionWithActiveLink];
 }
 
 #pragma mark - UIResponderStandardEditActions
@@ -1300,6 +1330,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     [coder encodeInteger:self.verticalAlignment forKey:NSStringFromSelector(@selector(verticalAlignment))];
     [coder encodeObject:self.truncationTokenString forKey:NSStringFromSelector(@selector(truncationTokenString))];
     [coder encodeObject:self.attributedText forKey:NSStringFromSelector(@selector(attributedText))];
+    [coder encodeObject:@(self.longPressInterval) forKey:NSStringFromSelector(@selector(longPressInterval))];
+    [coder encodeObject:@(self.selectionState) forKey:NSStringFromSelector(@selector(selectionState))];
 }
 
 - (id)initWithCoder:(NSCoder *)coder {
@@ -1370,6 +1402,14 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
     if ([coder containsValueForKey:NSStringFromSelector(@selector(attributedText))]) {
         self.attributedText = [coder decodeObjectForKey:NSStringFromSelector(@selector(attributedText))];
+    }
+
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(selectionState))]) {
+        self.longPressInterval = [coder decodeFloatForKey:NSStringFromSelector(@selector(longPressInterval))];
+    }
+
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(selectionState))]) {
+        self.selectionState = [coder decodeIntegerForKey:NSStringFromSelector(@selector(selectionState))];
     }
 
     return self;


### PR DESCRIPTION
Particular useful for use case that needed to perform different actions based on user actions.

Say normal tap goes to in-app browser, long pressing shows a dialog for copy link and open in Safari.

```
pod ‘TTTAttributedLabel’, :git => ‘https://github.com/jamztang/TTTAttributedLabel.git’, :branch => ‘longpresssupport’
```
