### PR TITLE
add method which return NSAttributedString from NSString 

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -234,7 +234,7 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
  
  @param NSString to become NSAttributedString
  
- @discussion sizeThatFitsAttributedString can calculate the size of TTTAttributedLabel instance, however it should get NSAttributedString in order to calculate. in order to get NSAttributedString, we can use the method "setText: afterInheritingLabelAttributesAndConfiguringWithBlock:", However the last method is a block and sometimes we dont want to use a block. for example when using inside UICollectionViewCell and the cell size should be calculated compare to the label size. in this case the block interfare with the flow calculation of the UICollectionView. This method just return the right attributed string for using afterward in the sizeThatFitsAttributedString method. this was tested in ios 7 and ios 6.  
+ @discussion sizeThatFitsAttributedString can calculate the size of TTTAttributedLabel instance, however it should get NSAttributedString in order to calculate. in order to get NSAttributedString, we can use the method "setText: afterInheritingLabelAttributesAndConfiguringWithBlock:", However the last method is a block and sometimes we dont want to use a block. for example when using inside UICollectionViewCell and the cell size should be calculated compare to the label size. in this case the block interfare with the flow calculation of the UICollectionView. This method just return the right attributed string for using afterward in the sizeThatFitsAttributedString method. this was tested in ios 7 and ios 6. if string is nil this function throw exception!
  @return NSAttributedString from the given NSString
 
   */

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1030,7 +1030,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     }
     else
     {
-        return nil;
+        [NSException raise:@"getAttributedTextFromString:, can not receive nil value" format:nil];
     }
 }
 


### PR DESCRIPTION
 @discussion sizeThatFitsAttributedString can calculate the size of TTTAttributedLabel instance, however it should get NSAttributedString in order to calculate. in order to get NSAttributedString, we can use the method "setText: afterInheritingLabelAttributesAndConfiguringWithBlock:", However the last method is a block and sometimes we dont want to use a block. for example when using inside UICollectionViewCell and the cell size should be calculated compare to the label size. in this case the block interfare with the flow calculation of the UICollectionView. This method just return the right attributed string for using afterward in the sizeThatFitsAttributedString method. this was tested in ios 7 and ios 6.  
here is example:
+(CGSize)sizeForDescriptionLabel:(APFeedEvent *)event
{
    CGSize textSize =  CGSizeZero;
![screen shot 2014-01-01 at 4 14 27 pm](https://f.cloud.github.com/assets/149232/1832259/e078795e-73ad-11e3-82a9-6eefd1a146f9.png)
![screen shot 2014-01-01 at 4 12 48 pm](https://f.cloud.github.com/assets/149232/1832260/e0a41e56-73ad-11e3-81c8-abcf6200df5e.png)

```
TTTAttributedLabel *temp = __dummyCell.eventDescriptionLabel;
NSAttributedString *string = [temp getAttributedTextFromString:event.text];
if ([string isKindOfClass:[NSAttributedString class]])
{
    textSize = [TTTAttributedLabel sizeThatFitsAttributedString:string withConstraints:CGSizeMake(TEWidthForCell, CGFLOAT_MAX) limitedToNumberOfLines:1000];
}

  return textSize;
```

}
