### PR TITLE
Added range check to -setActiveLink:

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1008,7 +1008,10 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         }
 
         NSMutableAttributedString *mutableAttributedString = [self.inactiveAttributedText mutableCopy];
-        [mutableAttributedString addAttributes:self.activeLinkAttributes range:_activeLink.range];
+        
+        if (NSMaxRange(_activeLink.range) <= mutableAttributedString.length)
+            [mutableAttributedString addAttributes:self.activeLinkAttributes range:_activeLink.range];
+        
         self.attributedText = mutableAttributedString;
 
         [self setNeedsDisplay];


### PR DESCRIPTION
I've been seeing a few crashes in my app, caused by `_activeLink.range` being out of `self.activeLinkAttributes`'s bounds. I've added a sanity check to ensure that the range is within the string's bounds, before adding the active link attributes.
