### PR TITLE
Invalidate the intrinsicContentSize

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -407,10 +407,12 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     [self setNeedsFramesetter];
     [self setNeedsDisplay];
     
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
     if([self respondsToSelector:@selector(invalidateIntrinsicContentSize)])
     {
         [self invalidateIntrinsicContentSize];
     }
+#endif
 }
 
 - (void)setNeedsFramesetter {


### PR DESCRIPTION
Was getting wonky layout issues when using TTTAttributedLabel in my UITableViewCell subclass that uses Auto Layout

The implementation of setAttributedText: should call invalidateIntrinsicContentSize per the docs:

```
Call this when something changes in your custom view that invalidates its intrinsic content size. This allows the constraint-based layout system to take the new intrinsic content size into account in its next layout pass.
```
