### PR TITLE
linkAttributes should override all other attributes within the link's range

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -125,7 +125,7 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
 /**
  A dictionary containing the `NSAttributedString` attributes to be applied to links detected or manually added to the label text. The default link style is blue and underlined.
  
- @warning You must specify `linkAttributes` before setting autodecting or manually-adding links for these attributes to be applied.
+ @warning These attributes will override any other attributes of the string at the link's range.  You must specify `linkAttributes` before setting auto-detecting or manually-adding links for these attributes to be applied.
  */
 @property (nonatomic, strong) NSDictionary *linkAttributes;
 
@@ -140,7 +140,7 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
 @property (nonatomic, strong) NSDictionary *inactiveLinkAttributes;
 
 ///---------------------------------------
-/// @name Acccessing Text Style Attributes
+/// @name Accessing Text Style Attributes
 ///---------------------------------------
 
 /**
@@ -167,7 +167,7 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
 @property (nonatomic, assign) CGFloat kern;
 
 ///--------------------------------------------
-/// @name Acccessing Paragraph Style Attributes
+/// @name Accessing Paragraph Style Attributes
 ///--------------------------------------------
 
 /**
@@ -231,7 +231,7 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
 
  @param attributedString The attributed string.
  @param size The maximum dimensions used to calculate size.
- @param numberOfLines The maximum number of lines in the text to draw, if the constraining size cannot accomodate the full attributed string.
+ @param numberOfLines The maximum number of lines in the text to draw, if the constraining size cannot accommodate the full attributed string.
  
  @return The size that fits the attributed string within the specified constraints.
  */
@@ -395,7 +395,7 @@ didSelectLinkWithPhoneNumber:(NSString *)phoneNumber;
  Tells the delegate that the user did select a link to a date.
  
  @param label The label whose link was selected.
- @param date The datefor the selected link.
+ @param date The date for the selected link.
  */
 - (void)attributedLabel:(TTTAttributedLabel *)label
   didSelectLinkWithDate:(NSDate *)date;

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1093,7 +1093,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         
     NSAttributedString *originalAttributedText = nil;
     
-    // Adjust the font size to fit width, if necessarry 
+    // Adjust the font size to fit width, if necessary
     if (self.adjustsFontSizeToFitWidth && self.numberOfLines > 0) {
         // Use infinite width to find the max width, which will be compared to availableWidth if needed.
         CGSize maxSize = (self.numberOfLines > 1) ? CGSizeMake(TTTFLOAT_MAX, TTTFLOAT_MAX) : CGSizeZero;


### PR DESCRIPTION
Hey Mattt,

I've come across a scenario where `addLinkToURL:withRange:` does not respect the `linkAttributes` and instead keeps the original attributes that were given when the `NSAttributedString` was created.

The issue exists because it is currently using `addAttributes` versus `setAttributes` in https://github.com/mattt/TTTAttributedLabel/blob/master/TTTAttributedLabel/TTTAttributedLabel.m#L513 so there's no guarantee which attribute it will keep if there are pre-existing attributes in that range.

I would expect the `linkAttributes` to take precedence versus attempting (and failing in this case) to be additive.   I've patched it to work and updated the docs, but it may break other people's implementations if they have been assuming it was additive all this time.

An example that causes it to fail:
- I created a basic `NSAttributedString` with a gray foreground color
- I then setup the `TTTAttributedLabel` like so:

``` objC
self.tttLabel.linkAttributes = @{ (id)kCTForegroundColorAttributeName : kSomeColorHere,
                                  (id)kCTUnderlineStyleAttributeName : [NSNumber numberWithInt:kCTUnderlineStyleNone] };
```
- Then I set the text using `setText:` and add a link (which I've verified is tappable in the UI)

However, when displayed, the link is still the gray foreground color instead of taking on the `linkAttributes`
