### PR TITLE
bug fix for #313

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -407,6 +407,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     
     _attributedText = [text copy];
     
+    self.links = [NSArray array];
+    
     [self setNeedsFramesetter];
     [self setNeedsDisplay];
     


### PR DESCRIPTION
This works for the bug I was experiencing. One way to recreate the problem is to put labels with links which appear near the end of the string so that when the table is scrolled the ranges for links go beyond the bounds of the current attributed string. The links array needs to be reset when the attributed text changes.
