### PR TITLE
Convert NSLinkAttributeName to NSTextCheckingResult when setting text

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -992,6 +992,19 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
             }
         });
     }
+    
+    [self.attributedText enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, self.attributedText.length) options:kNilOptions usingBlock:^(id value, NSRange range, BOOL *stop) {
+        if (!value) return;
+        
+        // NSLinkAttributeName can be NSURL or NSString
+        NSURL *URL;
+        if ([value isKindOfClass:NSString.class]) {
+            URL = [NSURL URLWithString:value];
+        } else {
+            URL = value;
+        }
+        [self addLinkToURL:URL withRange:range];
+    }];
 
     [super setText:[self.attributedText string]];
 }


### PR DESCRIPTION
TTTAttributedLabel does not consider `NSLinkAttributeName` attributes as links. This can be easily fixed by adding the value of those attributes to the `NSTextCheckingResult` list when setting the text.
