### PR TITLE
bug fix

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -969,7 +969,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     self.attributedText = text;
     self.activeLink = nil;
 
-    self.links = [NSArray array];
+    self.links = self.links ?: [NSArray array];
     if (self.attributedText && self.enabledTextCheckingTypes) {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 50000
         __unsafe_unretained __typeof(self)weakSelf = self;


### PR DESCRIPTION
this assignment resets all the links added in `setText:afterInheritingLabelAttributesAndConfiguringWithBlock:` 's block, that seems not to be intended reading #332
