### PR TITLE
iOS6 compatibility

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -979,13 +979,15 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
             }
         });
     }
-    
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
     [self.attributedText enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, self.attributedText.length) options:0 usingBlock:^(id value, __unused NSRange range, __unused BOOL *stop) {
         if (value) {
             NSURL *URL = [value isKindOfClass:[NSString class]] ? [NSURL URLWithString:value] : value;
             [self addLinkToURL:URL withRange:range];
         }
     }];
+#endif
 
     [super setText:[self.attributedText string]];
 }


### PR DESCRIPTION
tintColorDidChange and NSLinkAttributeName are iOS 7 only, we should preserve iOS 6 compatibility
