### PR TITLE
Fixes implementation of tintColorDidChange. 

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1196,10 +1196,10 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
 - (void)tintColorDidChange {
-    BOOL isInactive = (CGColorSpaceGetModel(CGColorGetColorSpace([self.tintColor CGColor])) == kCGColorSpaceModelMonochrome);
+    BOOL isInactive = self.tintAdjustmentMode == UIViewTintAdjustmentModeDimmed;
 
-    NSDictionary *attributesToRemove = isInactive ? self.linkAttributes : self.inactiveLinkAttributes;
-    NSDictionary *attributesToAdd = isInactive ? self.inactiveLinkAttributes : self.linkAttributes;
+    NSDictionary *attributesToRemove = isInactive ? self.activeLinkAttributes : self.inactiveLinkAttributes;
+    NSDictionary *attributesToAdd = isInactive ? self.inactiveLinkAttributes : self.activeLinkAttributes;
 
     NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
     for (NSTextCheckingResult *result in self.links) {


### PR DESCRIPTION
I was experiencing a crash in an app that was based around an older version of TTTAttributedLabel. It was crashing trying to add/remove the active/inactive attributes. 

It seems right to use active/inactive link attributes instead of the vanilla link attributes here, allowing you to properly opt out of this behaviour. 

A better way to detect `isInactive` was mentioned in  #352, since there was no PR for that, I have included that here too.
