### PR TITLE
Delegate method for non-link text selection

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -445,4 +445,12 @@ didSelectLinkWithTransitInformation:(NSDictionary *)components;
 - (void)attributedLabel:(TTTAttributedLabel *)label
 didSelectLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
 
+
+/**
+ Tells the delegate that the user did select an area without a link.
+
+ @param event The event that caused the delegate call.
+ */
+- (void)attributedLabel:(TTTAttributedLabel *)label didSelectNonLinkTextWithEvent:(UIEvent *)event;
+
 @end

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1305,6 +1305,9 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         }
     } else {
         [super touchesEnded:touches withEvent:event];
+        if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectNonLinkTextWithEvent:)]) {
+            [self.delegate attributedLabel:self didSelectNonLinkTextWithEvent:event];
+        }
     }
 }
 


### PR DESCRIPTION
Implemented a new optional delegate method on TTTAttributedLabelDelegate for selecting text without links.  I had a TTTAttributedLabel inside a UIButton and wanted the button to fire when non-link text is tapped.  For some reason the button does not receive the touch event despite the [super touchesEnded:withEvent] call that is issued if no link is selected.  Providing a optional delegate callback for this case seems reasonable.
