### PR TITLE
Opt out of inactive link styling when inactiveLinkAttributes is `nil` or empty.

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1198,6 +1198,10 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
 - (void)tintColorDidChange {
+    if (self.inactiveLinkAttributes.count==0) {
+        return;
+    }
+    
     BOOL isInactive = (self.tintAdjustmentMode == UIViewTintAdjustmentModeDimmed);
 
     NSDictionary *attributesToRemove = isInactive ? self.linkAttributes : self.inactiveLinkAttributes;


### PR DESCRIPTION
Check if inactiveLinkAttributes is 'nil' or empty when tintColorDidChange is called to opt out of inactive link styling.
