### PR TITLE
Fix iOS 6 crashing with VoiceOver on

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1251,20 +1251,40 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 #pragma mark - UIAccessibilityElement
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+- (BOOL)shouldSupportAccessibilityProtocol {
+    return ([NSURLSession class] != nil);
+}
+
 - (BOOL)isAccessibilityElement {
-    return NO;
+    if ([self shouldSupportAccessibilityProtocol]) {
+        return NO;
+    } else {
+        return [super isAccessibilityElement];
+    }
 }
 
 - (NSInteger)accessibilityElementCount {
-    return (NSInteger)[[self accessibilityElements] count];
+    if ([self shouldSupportAccessibilityProtocol]) {
+        return (NSInteger)[[self accessibilityElements] count];
+    } else {
+        return [super accessibilityElementCount];
+    }
 }
 
 - (id)accessibilityElementAtIndex:(NSInteger)index {
-    return [[self accessibilityElements] objectAtIndex:(NSUInteger)index];
+    if ([self shouldSupportAccessibilityProtocol]) {
+        return [[self accessibilityElements] objectAtIndex:(NSUInteger)index];
+    } else {
+        return [super accessibilityElementAtIndex:index];
+    }
 }
 
 - (NSInteger)indexOfAccessibilityElement:(id)element {
-    return (NSInteger)[[self accessibilityElements] indexOfObject:element];
+    if ([self shouldSupportAccessibilityProtocol]) {
+        return (NSInteger)[[self accessibilityElements] indexOfObject:element];
+    } else {
+        return [super indexOfAccessibilityElement:element];
+    }
 }
 
 - (NSArray *)accessibilityElements {


### PR DESCRIPTION
Check at runtime if this is iOS 7.  (This was crashing on iOS 6 devices built against the iOS 7 SDK.)

Note my gross hack here:

```
- (BOOL)shouldSupportAccessibilityProtocol {
    return ([NSURLSession class] != nil);
}
```

I tried testing for `NSTextStorage`, etc., but those were actually returned on iOS 6.  (I guess they were there, but private before.)

I'd like some commentary on a better run-time test, and also if anyone thinks this value should be cached.

Fixes https://github.com/mattt/TTTAttributedLabel/issues/396 and hopefully https://github.com/mattt/TTTAttributedLabel/issues/397 (although I couldn't reproduce the latter.)

CC @mattt @jhersh @sticksen @ksm
