### PR TITLE
Create TTTAttributedLabelLink class, and use it to manage default/active/inactive link state and accessibility values for non-default link types

### DIFF
--- a/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
+++ b/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
@@ -16,12 +16,14 @@
 static NSString * const kTestLabelText = @"Pallando, Merlyn, and Melisandre were walking one day...";
 static CGSize const kTestLabelSize = (CGSize) { 90, CGFLOAT_MAX };
 
+static inline NSDictionary * TTTAttributedTestAttributesDictionary() {
+    return @{NSForegroundColorAttributeName : [UIColor redColor],
+             NSFontAttributeName : [UIFont boldSystemFontOfSize:16.f]};
+}
+
 static inline NSAttributedString * TTTAttributedTestString() {
     return [[NSAttributedString alloc] initWithString:kTestLabelText
-                                           attributes:@{
-                                                    NSForegroundColorAttributeName : [UIColor redColor],
-                                                    NSFontAttributeName : [UIFont boldSystemFontOfSize:16.f],
-                                           }];
+                                           attributes:TTTAttributedTestAttributesDictionary()];
 }
 
 static inline void TTTSizeAttributedLabel(TTTAttributedLabel *label) {
@@ -42,6 +44,7 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     [window addSubview:label];
     [label longPressAtPoint:point duration:duration];
 };
+
 
 @interface TTTAttributedLabelTests : FBSnapshotTestCase
 
@@ -333,6 +336,47 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     label.text = string;
     TTTSizeAttributedLabel(label);
     FBSnapshotVerifyView(label, nil);
+}
+
+#pragma mark - TTTAttributedLabelLink tests
+
+- (void)testDesignatedInitializer {
+    NSTextCheckingResult *textResult = [NSTextCheckingResult spellCheckingResultWithRange:NSMakeRange(0, 4)];
+    TTTAttributedLabelLink *link = [[TTTAttributedLabelLink alloc] initWithAttributes:TTTAttributedTestAttributesDictionary()
+                                                                     activeAttributes:TTTAttributedTestAttributesDictionary()
+                                                                   inactiveAttributes:TTTAttributedTestAttributesDictionary()
+                                                                   textCheckingResult:textResult];
+    
+    XCTAssertEqualObjects(link.attributes, TTTAttributedTestAttributesDictionary());
+    XCTAssertEqualObjects(link.activeAttributes, TTTAttributedTestAttributesDictionary());
+    XCTAssertEqualObjects(link.inactiveAttributes, TTTAttributedTestAttributesDictionary());
+}
+
+- (void)testLabelInitializer {
+    NSTextCheckingResult *textResult = [NSTextCheckingResult spellCheckingResultWithRange:NSMakeRange(0, 4)];
+    TTTAttributedLabelLink *link = [[TTTAttributedLabelLink alloc] initWithAttributesFromLabel:label textCheckingResult:textResult];
+    
+    XCTAssertEqualObjects(link.attributes, label.linkAttributes);
+    XCTAssertEqualObjects(link.activeAttributes, label.activeLinkAttributes);
+    XCTAssertEqualObjects(link.inactiveAttributes, label.inactiveLinkAttributes);
+}
+
+- (void)testTextCheckingResultAttributesAreCorrectlyAssigned {
+    NSTextCheckingResult *textResult = [NSTextCheckingResult spellCheckingResultWithRange:NSMakeRange(0, 4)];
+    TTTAttributedLabelLink *link = [label addLinkWithTextCheckingResult:textResult attributes:TTTAttributedTestAttributesDictionary()];
+    
+    XCTAssertEqualObjects(link.attributes, TTTAttributedTestAttributesDictionary());
+    XCTAssertEqualObjects(link.activeAttributes, label.activeLinkAttributes);
+    XCTAssertEqualObjects(link.inactiveAttributes, label.inactiveLinkAttributes);
+}
+
+- (void)testTextCheckingResultAttributesAreCorrectlyAssignedWhenAttributesAreNil {
+    NSTextCheckingResult *textResult = [NSTextCheckingResult spellCheckingResultWithRange:NSMakeRange(0, 4)];
+    TTTAttributedLabelLink *link = [label addLinkWithTextCheckingResult:textResult attributes:nil];
+    
+    XCTAssertNil(link.attributes);
+    XCTAssertNil(link.activeAttributes);
+    XCTAssertNil(link.inactiveAttributes);
 }
 
 #pragma mark - TTTAttributedLabelDelegate tests

--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -23,6 +23,8 @@
 #import <UIKit/UIKit.h>
 #import <CoreText/CoreText.h>
 
+@class TTTAttributedLabelLink;
+
 /**
  Vertical alignment for text in a label whose bounds are larger than its text bounds
  */
@@ -79,6 +81,7 @@ IB_DESIGNABLE
  For the most part, `TTTAttributedLabel` behaves just like `UILabel`. The following are notable exceptions, in which `TTTAttributedLabel` may act differently:
  
  - `text` - This property now takes an `id` type argument, which can either be a kind of `NSString` or `NSAttributedString` (mutable or immutable in both cases)
+ - `attributedText` - Do not set this property directly. Instead, pass an `NSAttributedString` to `text`.
  - `lineBreakMode` - This property displays only the first line when the value is `UILineBreakModeHeadTruncation`, `UILineBreakModeTailTruncation`, or `UILineBreakModeMiddleTruncation`
  - `adjustsFontsizeToFitWidth` - Supported in iOS 5 and greater, this property is effective for any value of `numberOfLines` greater than zero. In iOS 4, setting `numberOfLines` to a value greater than 1 with `adjustsFontSizeToFitWidth` set to `YES` may cause `sizeToFit` to execute indefinitely.
  - `baselineAdjustment` - This property has no affect.
@@ -130,19 +133,19 @@ IB_DESIGNABLE
 @property (readonly, nonatomic, strong) NSArray *links;
 
 /**
- A dictionary containing the `NSAttributedString` attributes to be applied to links detected or manually added to the label text. The default link style is blue and underlined.
+ A dictionary containing the default `NSAttributedString` attributes to be applied to links detected or manually added to the label text. The default link style is blue and underlined.
  
  @warning You must specify `linkAttributes` before setting autodecting or manually-adding links for these attributes to be applied.
  */
 @property (nonatomic, strong) NSDictionary *linkAttributes;
 
 /**
- A dictionary containing the `NSAttributedString` attributes to be applied to links when they are in the active state. If `nil` or an empty `NSDictionary`, active links will not be styled. The default active link style is red and underlined.
+ A dictionary containing the default `NSAttributedString` attributes to be applied to links when they are in the active state. If `nil` or an empty `NSDictionary`, active links will not be styled. The default active link style is red and underlined.
  */
 @property (nonatomic, strong) NSDictionary *activeLinkAttributes;
 
 /**
- A dictionary containing the `NSAttributedString` attributes to be applied to links when they are in the inactive state, which is triggered a change in `tintColor` in iOS 7. If `nil` or an empty `NSDictionary`, inactive links will not be styled. The default inactive link style is gray and unadorned.
+ A dictionary containing the default `NSAttributedString` attributes to be applied to links when they are in the inactive state, which is triggered by a change in `tintColor` in iOS 7 and later. If `nil` or an empty `NSDictionary`, inactive links will not be styled. The default inactive link style is gray and unadorned.
  */
 @property (nonatomic, strong) NSDictionary *inactiveLinkAttributes;
 
@@ -301,12 +304,14 @@ IB_DESIGNABLE
 - (void)setText:(id)text
 afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString *(^)(NSMutableAttributedString *mutableAttributedString))block;
 
-///----------------------------------
+///------------------------------------
 /// @name Accessing the Text Attributes
-///----------------------------------
+///------------------------------------
 
 /**
  A copy of the label's current attributedText. This returns `nil` if an attributed string has never been set on the label.
+ 
+ @warning Do not set this property directly. Instead, set `text` to an NSAttributedString.
  */
 @property (readwrite, nonatomic, copy) NSAttributedString *attributedText;
 
@@ -315,20 +320,29 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 ///-------------------
 
 /**
- Adds a link to an `NSTextCheckingResult`.
+ Adds a link. You can customize an individual link's appearance and accessibility value by creating your own `TTTAttributedLabelLink` and passing it to this method. The other methods for adding links will use the label's default attributes.
  
- @param result An `NSTextCheckingResult` representing the link's location and type.
+ @warning Modifying the link's attribute dictionaries must be done before calling this method.
+ 
+ @param link A `TTTAttributedLabelLink` object.
  */
-- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
+- (void)addLink:(TTTAttributedLabelLink *)link;
 
 /**
  Adds a link to an `NSTextCheckingResult`.
  
  @param result An `NSTextCheckingResult` representing the link's location and type.
- @param attributes The attributes to be added to the text in the range of the specified link. If `nil`, no attributes are added.
  */
-- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result
-                           attributes:(NSDictionary *)attributes;
+- (TTTAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
+
+/**
+ Adds a link to an `NSTextCheckingResult`.
+ 
+ @param result An `NSTextCheckingResult` representing the link's location and type.
+ @param attributes The attributes to be added to the text in the range of the specified link. If set, the label's activeAttributes and inactiveAttributes will be applied to the link. If `nil`, no attributes are added to the link.
+ */
+- (TTTAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result
+                                               attributes:(NSDictionary *)attributes;
 
 /**
  Adds a link to a URL for a specified range in the label text.
@@ -336,8 +350,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  @param url The url to be linked to
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
  */
-- (void)addLinkToURL:(NSURL *)url
-           withRange:(NSRange)range;
+- (TTTAttributedLabelLink *)addLinkToURL:(NSURL *)url
+                               withRange:(NSRange)range;
 
 /**
  Adds a link to an address for a specified range in the label text.
@@ -347,8 +361,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  
  @discussion The address component dictionary keys are described in `NSTextCheckingResult`'s "Keys for Address Components." 
  */
-- (void)addLinkToAddress:(NSDictionary *)addressComponents
-               withRange:(NSRange)range;
+- (TTTAttributedLabelLink *)addLinkToAddress:(NSDictionary *)addressComponents
+                                   withRange:(NSRange)range;
 
 /**
  Adds a link to a phone number for a specified range in the label text.
@@ -356,8 +370,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  @param phoneNumber The phone number to be linked to.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
  */
-- (void)addLinkToPhoneNumber:(NSString *)phoneNumber
-                   withRange:(NSRange)range;
+- (TTTAttributedLabelLink *)addLinkToPhoneNumber:(NSString *)phoneNumber
+                                       withRange:(NSRange)range;
 
 /**
  Adds a link to a date for a specified range in the label text.
@@ -365,8 +379,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  @param date The date to be linked to.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
  */
-- (void)addLinkToDate:(NSDate *)date
-            withRange:(NSRange)range;
+- (TTTAttributedLabelLink *)addLinkToDate:(NSDate *)date
+                                withRange:(NSRange)range;
 
 /**
  Adds a link to a date with a particular time zone and duration for a specified range in the label text.
@@ -376,10 +390,10 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  @param duration The duration, in seconds from the specified date.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
  */
-- (void)addLinkToDate:(NSDate *)date
-             timeZone:(NSTimeZone *)timeZone
-             duration:(NSTimeInterval)duration
-            withRange:(NSRange)range;
+- (TTTAttributedLabelLink *)addLinkToDate:(NSDate *)date
+                                 timeZone:(NSTimeZone *)timeZone
+                                 duration:(NSTimeInterval)duration
+                                withRange:(NSRange)range;
 
 /**
  Adds a link to transit information for a specified range in the label text.
@@ -387,8 +401,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  @param components A dictionary containing the transit components. The currently supported keys are `NSTextCheckingAirlineKey` and `NSTextCheckingFlightKey`.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
  */
-- (void)addLinkToTransitInformation:(NSDictionary *)components
-                          withRange:(NSRange)range;
+- (TTTAttributedLabelLink *)addLinkToTransitInformation:(NSDictionary *)components
+                                              withRange:(NSRange)range;
 
 /**
  Returns whether an `NSTextCheckingResult` is found at the give point.
@@ -574,5 +588,56 @@ didLongPressLinkWithTransitInformation:(NSDictionary *)components
 - (void)attributedLabel:(TTTAttributedLabel *)label
 didLongPressLinkWithTextCheckingResult:(NSTextCheckingResult *)result
                 atPoint:(CGPoint)point;
+
+@end
+
+@interface TTTAttributedLabelLink : NSObject <NSCoding>
+
+/**
+ An `NSTextCheckingResult` representing the link's location and type.
+ */
+@property (readonly, nonatomic, strong) NSTextCheckingResult *result;
+
+/**
+ A dictionary containing the @c NSAttributedString attributes to be applied to the link.
+ */
+@property (readonly, nonatomic, strong) NSDictionary *attributes;
+
+/**
+ A dictionary containing the @c NSAttributedString attributes to be applied to the link when it is in the active state.
+ */
+@property (readonly, nonatomic, strong) NSDictionary *activeAttributes;
+
+/**
+ A dictionary containing the @c NSAttributedString attributes to be applied to the link when it is in the inactive state, which is triggered by a change in `tintColor` in iOS 7 and later.
+ */
+@property (readonly, nonatomic, strong) NSDictionary *inactiveAttributes;
+
+/**
+ Additional information about a link for VoiceOver users. Has default values if the link's @c result is @c NSTextCheckingTypeLink, @c NSTextCheckingTypePhoneNumber, or @c NSTextCheckingTypeDate.
+ */
+@property (nonatomic, strong) NSString *accessibilityValue;
+
+/**
+ Initializes a link using the attribute dictionaries set on a specified label.
+ 
+ @param attributes         The @c attributes property for the link.
+ @param activeAttributes   The @c activeAttributes property for the link.
+ @param inactiveAttributes The @c inactiveAttributes property for the link.
+ @param result             An @c NSTextCheckingResult representing the link's location and type.
+ 
+ @return The initialized link object.
+ */
+- (instancetype)initWithAttributes:(NSDictionary *)attributes activeAttributes:(NSDictionary *)activeAttributes inactiveAttributes:(NSDictionary *)inactiveAttributes textCheckingResult:(NSTextCheckingResult *)result;
+
+/**
+ Initializes a link using the attribute dictionaries set on a specified label.
+ 
+ @param label  The attributed label from which to inherit attribute dictionaries.
+ @param result An @c NSTextCheckingResult representing the link's location and type.
+ 
+ @return The initialized link object.
+ */
+- (instancetype)initWithAttributesFromLabel:(TTTAttributedLabel*)label textCheckingResult:(NSTextCheckingResult *)result;
 
 @end

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -310,8 +310,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 @property (readwrite, nonatomic, copy) NSAttributedString *inactiveAttributedText;
 @property (readwrite, nonatomic, copy) NSAttributedString *renderedAttributedText;
 @property (readwrite, atomic, strong) NSDataDetector *dataDetector;
-@property (readwrite, nonatomic, strong) NSArray *links;
-@property (readwrite, nonatomic, strong) NSTextCheckingResult *activeLink;
+@property (readwrite, nonatomic, strong) NSArray *linkModels;
+@property (readwrite, nonatomic, strong) TTTAttributedLabelLink *activeLink;
 @property (readwrite, nonatomic, strong) NSArray *accessibilityElements;
 
 - (void) longPressGestureDidFire:(UILongPressGestureRecognizer *)sender;
@@ -377,7 +377,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     self.textInsets = UIEdgeInsetsZero;
     self.lineHeightMultiple = 1.0f;
 
-    self.links = [NSArray array];
+    self.linkModels = [NSArray array];
 
     self.linkBackgroundEdgeInset = UIEdgeInsetsMake(0.0f, -1.0f, 0.0f, -1.0f);
 
@@ -470,9 +470,13 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     return _renderedAttributedText;
 }
 
-- (void)setLinks:(NSArray *)links {
-    _links = links;
+- (NSArray *) links {
+    return [_linkModels valueForKey:@"result"];
+}
 
+- (void)setLinkModels:(NSArray *)linkModels {
+    _linkModels = linkModels;
+    
     self.accessibilityElements = nil;
 }
 
@@ -560,70 +564,97 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     }
 }
 
-- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result
-                           attributes:(NSDictionary *)attributes
-{
-    [self addLinksWithTextCheckingResults:[NSArray arrayWithObject:result] attributes:attributes];
+- (void)addLink:(TTTAttributedLabelLink *)link {
+    [self addLinks:@[link]];
 }
 
-- (void)addLinksWithTextCheckingResults:(NSArray *)results
-                             attributes:(NSDictionary *)attributes
-{
-    NSMutableArray *mutableLinks = [NSMutableArray arrayWithArray:self.links];
-    if (attributes) {
-        NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
-        for (NSTextCheckingResult *result in results) {
-            [mutableAttributedString addAttributes:attributes range:result.range];
+- (void)addLinks:(NSArray *)links {
+    NSMutableArray *mutableLinkModels = [NSMutableArray arrayWithArray:self.linkModels];
+    
+    NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
+
+    for (TTTAttributedLabelLink *link in links) {
+        if (link.attributes) {
+            [mutableAttributedString addAttributes:link.attributes range:link.result.range];
         }
-
-        self.attributedText = mutableAttributedString;
-        [self setNeedsDisplay];
     }
-    [mutableLinks addObjectsFromArray:results];
 
-    self.links = [NSArray arrayWithArray:mutableLinks];
+    self.attributedText = mutableAttributedString;
+    [self setNeedsDisplay];
+
+    [mutableLinkModels addObjectsFromArray:links];
+    
+    self.linkModels = [NSArray arrayWithArray:mutableLinkModels];
 }
 
-- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result {
-    [self addLinkWithTextCheckingResult:result attributes:self.linkAttributes];
-}
-
-- (void)addLinkToURL:(NSURL *)url
-           withRange:(NSRange)range
+- (TTTAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result
+                                               attributes:(NSDictionary *)attributes
 {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult linkCheckingResultWithRange:range URL:url]];
+    return [self addLinksWithTextCheckingResults:@[result] attributes:attributes].firstObject;
 }
 
-- (void)addLinkToAddress:(NSDictionary *)addressComponents
-               withRange:(NSRange)range
+- (NSArray *)addLinksWithTextCheckingResults:(NSArray *)results
+                                  attributes:(NSDictionary *)attributes
 {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult addressCheckingResultWithRange:range components:addressComponents]];
+    NSMutableArray *links = [NSMutableArray array];
+    
+    for (NSTextCheckingResult *result in results) {
+        NSDictionary *activeAttributes = attributes ? self.activeLinkAttributes : nil;
+        NSDictionary *inactiveAttributes = attributes ? self.inactiveLinkAttributes : nil;
+        
+        TTTAttributedLabelLink *link = [[TTTAttributedLabelLink alloc] initWithAttributes:attributes
+                                                                         activeAttributes:activeAttributes
+                                                                       inactiveAttributes:inactiveAttributes
+                                                                       textCheckingResult:result];
+        
+        [links addObject:link];
+    }
+    
+    [self addLinks:links];
+    
+    return links;
 }
 
-- (void)addLinkToPhoneNumber:(NSString *)phoneNumber
-                   withRange:(NSRange)range
+- (TTTAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result {
+    return [self addLinkWithTextCheckingResult:result attributes:self.linkAttributes];
+}
+
+- (TTTAttributedLabelLink *)addLinkToURL:(NSURL *)url
+                               withRange:(NSRange)range
 {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult phoneNumberCheckingResultWithRange:range phoneNumber:phoneNumber]];
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult linkCheckingResultWithRange:range URL:url]];
 }
 
-- (void)addLinkToDate:(NSDate *)date
+- (TTTAttributedLabelLink *)addLinkToAddress:(NSDictionary *)addressComponents
+                                   withRange:(NSRange)range
+{
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult addressCheckingResultWithRange:range components:addressComponents]];
+}
+
+- (TTTAttributedLabelLink *)addLinkToPhoneNumber:(NSString *)phoneNumber
+                                       withRange:(NSRange)range
+{
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult phoneNumberCheckingResultWithRange:range phoneNumber:phoneNumber]];
+}
+
+- (TTTAttributedLabelLink *)addLinkToDate:(NSDate *)date
             withRange:(NSRange)range
 {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult dateCheckingResultWithRange:range date:date]];
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult dateCheckingResultWithRange:range date:date]];
 }
 
-- (void)addLinkToDate:(NSDate *)date
-             timeZone:(NSTimeZone *)timeZone
-             duration:(NSTimeInterval)duration
-            withRange:(NSRange)range
+- (TTTAttributedLabelLink *)addLinkToDate:(NSDate *)date
+                                 timeZone:(NSTimeZone *)timeZone
+                                 duration:(NSTimeInterval)duration
+                                withRange:(NSRange)range
 {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult dateCheckingResultWithRange:range date:date timeZone:timeZone duration:duration]];
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult dateCheckingResultWithRange:range date:date timeZone:timeZone duration:duration]];
 }
 
-- (void)addLinkToTransitInformation:(NSDictionary *)components
-                          withRange:(NSRange)range
+- (TTTAttributedLabelLink *)addLinkToTransitInformation:(NSDictionary *)components
+                                              withRange:(NSRange)range
 {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult transitInformationCheckingResultWithRange:range components:components]];
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult transitInformationCheckingResultWithRange:range components:components]];
 }
 
 #pragma mark -
@@ -632,7 +663,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     return [self linkAtPoint:point] != nil;
 }
 
-- (NSTextCheckingResult *)linkAtPoint:(CGPoint)point {
+- (TTTAttributedLabelLink *)linkAtPoint:(CGPoint)point {
     
     // Stop quickly if none of the points to be tested are in the bounds.
     if (!CGRectContainsPoint(CGRectInset(self.bounds, -15.f, -15.f), point) || self.links.count == 0) {
@@ -648,7 +679,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
         ?: [self linkAtRadius:15.f aroundPoint:point];
 }
 
-- (NSTextCheckingResult *)linkAtRadius:(const CGFloat)radius aroundPoint:(CGPoint)point {
+- (TTTAttributedLabelLink *)linkAtRadius:(const CGFloat)radius aroundPoint:(CGPoint)point {
     const CGFloat diagonal = CGFloat_sqrt(2 * radius * radius);
     const CGPoint deltas[] = {
         CGPointMake(0, -radius), CGPointMake(0, radius), // Above and below
@@ -658,28 +689,27 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     };
     const size_t count = sizeof(deltas) / sizeof(CGPoint);
     
-    NSTextCheckingResult *result = nil;
+    TTTAttributedLabelLink *link = nil;
     
-    for (NSInteger i = 0; i < count && result == nil; i ++) {
+    for (NSInteger i = 0; i < count && link.result == nil; i ++) {
         CGPoint currentPoint = CGPointMake(point.x + deltas[i].x, point.y + deltas[i].y);
-        result = [self linkAtCharacterIndex:[self characterIndexAtPoint:currentPoint]];
+        link = [self linkAtCharacterIndex:[self characterIndexAtPoint:currentPoint]];
     }
     
-    return result;
+    return link;
 }
 
-- (NSTextCheckingResult *)linkAtCharacterIndex:(CFIndex)idx {
-    
+- (TTTAttributedLabelLink *)linkAtCharacterIndex:(CFIndex)idx {
     // Do not enumerate if the index is outside of the bounds of the text.
     if (!NSLocationInRange((NSUInteger)idx, NSMakeRange(0, self.attributedText.length))) {
         return nil;
     }
     
-    NSEnumerator *enumerator = [self.links reverseObjectEnumerator];
-    NSTextCheckingResult *result = nil;
-    while ((result = [enumerator nextObject])) {
-        if (NSLocationInRange((NSUInteger)idx, result.range)) {
-            return result;
+    NSEnumerator *enumerator = [self.linkModels reverseObjectEnumerator];
+    TTTAttributedLabelLink *link = nil;
+    while ((link = [enumerator nextObject])) {
+        if (NSLocationInRange((NSUInteger)idx, link.result.range)) {
+            return link;
         }
     }
 
@@ -1074,7 +1104,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     self.attributedText = text;
     self.activeLink = nil;
 
-    self.links = [NSArray array];
+    self.linkModels = [NSArray array];
     if (self.attributedText && self.enabledTextCheckingTypes) {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 50000
         __unsafe_unretained __typeof(self)weakSelf = self;
@@ -1128,17 +1158,19 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     [self setText:mutableAttributedString];
 }
 
-- (void)setActiveLink:(NSTextCheckingResult *)activeLink {
+- (void)setActiveLink:(TTTAttributedLabelLink *)activeLink {
     _activeLink = activeLink;
+    
+    NSDictionary *activeAttributes = activeLink.activeAttributes ?: self.activeLinkAttributes;
 
-    if (_activeLink && [self.activeLinkAttributes count] > 0) {
+    if (_activeLink && activeAttributes.count > 0) {
         if (!self.inactiveAttributedText) {
             self.inactiveAttributedText = [self.attributedText copy];
         }
 
         NSMutableAttributedString *mutableAttributedString = [self.inactiveAttributedText mutableCopy];
-        if (self.activeLink.range.length > 0 && NSLocationInRange(NSMaxRange(self.activeLink.range) - 1, NSMakeRange(0, [self.inactiveAttributedText length]))) {
-            [mutableAttributedString addAttributes:self.activeLinkAttributes range:self.activeLink.range];
+        if (self.activeLink.result.range.length > 0 && NSLocationInRange(NSMaxRange(self.activeLink.result.range) - 1, NSMakeRange(0, [self.inactiveAttributedText length]))) {
+            [mutableAttributedString addAttributes:activeAttributes range:self.activeLink.result.range];
         }
 
         self.attributedText = mutableAttributedString;
@@ -1324,30 +1356,16 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         @synchronized(self) {
             NSMutableArray *mutableAccessibilityItems = [NSMutableArray array];
 
-            for (NSTextCheckingResult *result in self.links) {
+            for (TTTAttributedLabelLink *link in self.linkModels) {
                 NSString *sourceText = [self.text isKindOfClass:[NSString class]] ? self.text : [(NSAttributedString *)self.text string];
 
-                NSString *accessibilityLabel = [sourceText substringWithRange:result.range];
-                NSString *accessibilityValue = nil;
-
-                switch (result.resultType) {
-                    case NSTextCheckingTypeLink:
-                        accessibilityValue = result.URL.absoluteString;
-                        break;
-                    case NSTextCheckingTypePhoneNumber:
-                        accessibilityValue = result.phoneNumber;
-                        break;
-                    case NSTextCheckingTypeDate:
-                        accessibilityValue = [NSDateFormatter localizedStringFromDate:result.date dateStyle:NSDateFormatterLongStyle timeStyle:NSDateFormatterLongStyle];
-                        break;
-                    default:
-                        break;
-                }
+                NSString *accessibilityLabel = [sourceText substringWithRange:link.result.range];
+                NSString *accessibilityValue = link.accessibilityValue;
 
                 if (accessibilityLabel) {
                     UIAccessibilityElement *linkElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
                     linkElement.accessibilityTraits = UIAccessibilityTraitLink;
-                    linkElement.accessibilityFrame = [self convertRect:[self boundingRectForCharacterRange:result.range] toView:self.window];
+                    linkElement.accessibilityFrame = [self convertRect:[self boundingRectForCharacterRange:link.result.range] toView:self.window];
                     linkElement.accessibilityLabel = accessibilityLabel;
 
                     if (![accessibilityLabel isEqualToString:accessibilityValue]) {
@@ -1402,20 +1420,20 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
     BOOL isInactive = (self.tintAdjustmentMode == UIViewTintAdjustmentModeDimmed);
 
-    NSDictionary *attributesToRemove = isInactive ? self.linkAttributes : self.inactiveLinkAttributes;
-    NSDictionary *attributesToAdd = isInactive ? self.inactiveLinkAttributes : self.linkAttributes;
-
     NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
-    for (NSTextCheckingResult *result in self.links) {
+    for (TTTAttributedLabelLink *link in self.linkModels) {
+        NSDictionary *attributesToRemove = isInactive ? link.attributes : link.inactiveAttributes;
+        NSDictionary *attributesToAdd = isInactive ? link.inactiveAttributes : link.attributes;
+        
         [attributesToRemove enumerateKeysAndObjectsUsingBlock:^(NSString *name, __unused id value, __unused BOOL *stop) {
-            if (NSMaxRange(result.range) <= mutableAttributedString.length) {
-                [mutableAttributedString removeAttribute:name range:result.range];
+            if (NSMaxRange(link.result.range) <= mutableAttributedString.length) {
+                [mutableAttributedString removeAttribute:name range:link.result.range];
             }
         }];
 
         if (attributesToAdd) {
-            if (NSMaxRange(result.range) <= mutableAttributedString.length) {
-                [mutableAttributedString addAttributes:attributesToAdd range:result.range];
+            if (NSMaxRange(link.result.range) <= mutableAttributedString.length) {
+                [mutableAttributedString addAttributes:attributesToAdd range:link.result.range];
             }
         }
     }
@@ -1478,7 +1496,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
            withEvent:(UIEvent *)event
 {
     if (self.activeLink) {
-        NSTextCheckingResult *result = self.activeLink;
+        NSTextCheckingResult *result = self.activeLink.result;
         self.activeLink = nil;
 
         switch (result.resultType) {
@@ -1543,7 +1561,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     switch (sender.state) {
         case UIGestureRecognizerStateBegan: {
             CGPoint touchPoint = [sender locationInView:self];
-            NSTextCheckingResult *result = [self linkAtPoint:touchPoint];
+            NSTextCheckingResult *result = [self linkAtPoint:touchPoint].result;
             
             if (result) {
                 switch (result.resultType) {
@@ -1608,7 +1626,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
     [coder encodeObject:@(self.enabledTextCheckingTypes) forKey:NSStringFromSelector(@selector(enabledTextCheckingTypes))];
 
-    [coder encodeObject:self.links forKey:NSStringFromSelector(@selector(links))];
+    [coder encodeObject:self.linkModels forKey:NSStringFromSelector(@selector(linkModels))];
     if ([NSMutableParagraphStyle class]) {
         [coder encodeObject:self.linkAttributes forKey:NSStringFromSelector(@selector(linkAttributes))];
         [coder encodeObject:self.activeLinkAttributes forKey:NSStringFromSelector(@selector(activeLinkAttributes))];
@@ -1647,10 +1665,6 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         self.enabledTextCheckingTypes = [[coder decodeObjectForKey:NSStringFromSelector(@selector(enabledTextCheckingTypes))] unsignedLongLongValue];
     }
 
-    if ([coder containsValueForKey:NSStringFromSelector(@selector(links))]) {
-        self.links = [coder decodeObjectForKey:NSStringFromSelector(@selector(links))];
-    }
-
     if ([NSMutableParagraphStyle class]) {
         if ([coder containsValueForKey:NSStringFromSelector(@selector(linkAttributes))]) {
             self.linkAttributes = [coder decodeObjectForKey:NSStringFromSelector(@selector(linkAttributes))];
@@ -1663,6 +1677,15 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         if ([coder containsValueForKey:NSStringFromSelector(@selector(inactiveLinkAttributes))]) {
             self.inactiveLinkAttributes = [coder decodeObjectForKey:NSStringFromSelector(@selector(inactiveLinkAttributes))];
         }
+    }
+
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(links))]) {
+        NSArray *oldLinks = [coder decodeObjectForKey:NSStringFromSelector(@selector(links))];
+        [self addLinksWithTextCheckingResults:oldLinks attributes:nil];
+    }
+
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(linkModels))]) {
+        self.linkModels = [coder decodeObjectForKey:NSStringFromSelector(@selector(linkModels))];
     }
 
     if ([coder containsValueForKey:NSStringFromSelector(@selector(shadowRadius))]) {
@@ -1729,6 +1752,96 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     } else {
         self.text = super.text;
     }
+    
+    return self;
+}
+
+@end
+
+@interface TTTAttributedLabelLink ()
+
+@property (nonatomic, strong) NSTextCheckingResult *result;
+@property (nonatomic, strong) NSDictionary *attributes;
+@property (nonatomic, strong) NSDictionary *activeAttributes;
+@property (nonatomic, strong) NSDictionary *inactiveAttributes;
+
+@end
+
+@implementation TTTAttributedLabelLink
+
+- (instancetype)initWithAttributes:(NSDictionary *)attributes activeAttributes:(NSDictionary *)activeAttributes inactiveAttributes:(NSDictionary *)inactiveAttributes textCheckingResult:(NSTextCheckingResult *)result {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    self.result = result;
+    
+    self.attributes = attributes;
+    self.activeAttributes = activeAttributes;
+    self.inactiveAttributes = inactiveAttributes;
+    
+    return self;
+}
+
+- (instancetype)initWithAttributesFromLabel:(TTTAttributedLabel*)label textCheckingResult:(NSTextCheckingResult *)result {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    self.result = result;
+    
+    self.attributes = label.linkAttributes;
+    self.activeAttributes = label.activeLinkAttributes;
+    self.inactiveAttributes = label.inactiveLinkAttributes;
+    
+    return self;
+}
+
+#pragma mark - Accessibility
+
+- (NSString *) accessibilityValue {
+    if (!_accessibilityValue) {
+        switch (self.result.resultType) {
+            case NSTextCheckingTypeLink:
+                _accessibilityValue = self.result.URL.absoluteString;
+                break;
+            case NSTextCheckingTypePhoneNumber:
+                _accessibilityValue = self.result.phoneNumber;
+                break;
+            case NSTextCheckingTypeDate:
+                _accessibilityValue = [NSDateFormatter localizedStringFromDate:self.result.date dateStyle:NSDateFormatterLongStyle timeStyle:NSDateFormatterLongStyle];
+                break;
+            default:
+                break;
+        }
+    }
+    
+    return _accessibilityValue;
+}
+
+#pragma mark - NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeObject:self.result forKey:NSStringFromSelector(@selector(result))];
+    [aCoder encodeObject:self.attributes forKey:NSStringFromSelector(@selector(attributes))];
+    [aCoder encodeObject:self.activeAttributes forKey:NSStringFromSelector(@selector(activeAttributes))];
+    [aCoder encodeObject:self.inactiveAttributes forKey:NSStringFromSelector(@selector(inactiveAttributes))];
+    [aCoder encodeObject:self.accessibilityValue forKey:NSStringFromSelector(@selector(accessibilityValue))];
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    self.result = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(result))];
+    self.attributes = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(attributes))];
+    self.activeAttributes = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(activeAttributes))];
+    self.inactiveAttributes = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(inactiveAttributes))];
+    self.accessibilityValue = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(accessibilityValue))];
     
     return self;
 }


### PR DESCRIPTION
- Create TTTAttributedLabelLink class, and use it to manage default/active/inactive link state and accessibility values for non-default link types
- Updates example project to compile properly with this new class
- Update documentation