### PR TITLE
Added some customizability features

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -386,7 +386,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  
  @param point The point inside the label to test at.
  */
-- (BOOL)containslinkAtPoint:(CGPoint)point;
+- (BOOL)containslinkAtPoint:(CGPoint)p;
 
 @end
 

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -645,7 +645,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     return [self linkAtCharacterIndex:idx];
 }
 
-- (BOOL)containslinkAtPoint:(CGPoint)point {
+- (BOOL)containslinkAtPoint:(CGPoint)p {
     CFIndex idx = [self characterIndexAtPoint:p];
     
     return ([self linkAtCharacterIndex:idx] != nil);


### PR DESCRIPTION
- Added the ability to use links in "truncationTokenString"
- Added the ability to shift the background for link taps 
- Added "containsLinkAtPoint:" so you can make custom UIViews with a UITapGestureRecognizer and TTTAttributedLabel (see below)

"containsLinkAtPoint:" was needed when I created a UIView that was going to be used in a UITableView as "sticky" header. It contained 1-2 links to the user profile and the action the performed. However when you tapped the background it should also go to the action. That was not possible with TTTAttributedLabel, when you add a UITapGestureRecognizer to the superview of the TTTAttributedLabel the links in TTTAttributedLabel would stop working. If you made a custom subview that was below the TTTAttributedLabel and put the UITapGestureRecognizer on that it would not work when tapping inside the label where no link is.

Now in order to get it working you have to check in the delegate of the UITapGestureRecognizer if there is a link at that point. 

``` Obj-c
-(BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
    CGPoint locationInLabel = [gestureRecognizer locationInView:self.attributedLabel];
    if ([self.attributedLabel containslinkAtPoint:locationInLabel]) {
        return NO;
    }
    return YES;
}
```
