### PR TITLE
Enable optional tap through

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -93,6 +93,17 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
 @interface TTTAttributedLabel : UILabel <TTTAttributedLabel, UIGestureRecognizerDelegate>
 
 ///-----------------------------
+/// @name Misc settings
+///-----------------------------
+
+/**
+ Whether it should be possible to tap throught the label if tapping outside a link.
+ 
+ @discussion If this property is set to YES, tapping outside of a link will pass the tap through to the view behind it. This for example allows selection of a UITableViewCell that has a TTTAttributedLabel with links where the label has userInteractionEnabled = YES and covers most of the view.
+ */
+@property (nonatomic) BOOL allowsTapThrough;
+
+///-----------------------------
 /// @name Accessing the Delegate
 ///-----------------------------
 

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1415,6 +1415,19 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     return (action == @selector(copy:));
 }
 
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
+    if ([super pointInside:point withEvent:event]) {
+        if (self.allowsTapThrough && ![self linkAtPoint:point]) {
+            return NO;
+        } else {
+            return YES;
+        }
+    } else {
+        return NO;
+    }
+}
+
 - (void)touchesBegan:(NSSet *)touches
            withEvent:(UIEvent *)event
 {


### PR DESCRIPTION
This is useful if you have a cell with a TTTAttributedLabel covering the entire contentView and a small link somewhere in the text. You want to be able to tap the link, so userInteractionEnabled must be true for the entire label, but you also want to be able to tap outside of the link and select the cell and perhaps trigger a segue.

Setting allowsTapThrough to true checks if the user tapped a link, and if not it ignores the touch and lets the next view handle it.
