### PR TITLE
added range check before editing link attributes when changing tint color

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1384,7 +1384,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
             
             if (range.location + range.length > mutableAttributedString.length) {
                 
-                if (mutableAttributedString.length - range.location > 0) {
+                if ((NSInteger)mutableAttributedString.length - (NSInteger)range.location > 0) {
                     range.length = mutableAttributedString.length - range.location;
                 }
                 else {
@@ -1401,7 +1401,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
             
             if (range.location + range.length > mutableAttributedString.length) {
                 
-                if (mutableAttributedString.length - range.location > 0) {
+                if ((NSInteger)mutableAttributedString.length - (NSInteger)range.location > 0) {
                     range.length = mutableAttributedString.length - range.location;
                 }
                 else {


### PR DESCRIPTION
Reliably got an out of bounds exception under certain circumstances (link in label, label in table cell, then scroll and do some animated view changes). Possibly also fixes #435. 
