### PR TITLE
Switched NSDataDetector from "nonatomic" to "atomic"

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -302,7 +302,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 @interface TTTAttributedLabel ()
 @property (readwrite, nonatomic, copy) NSAttributedString *inactiveAttributedText;
 @property (readwrite, nonatomic, copy) NSAttributedString *renderedAttributedText;
-@property (readwrite, nonatomic, strong) NSDataDetector *dataDetector;
+@property (readwrite, atomic, strong) NSDataDetector *dataDetector;
 @property (readwrite, nonatomic, strong) NSArray *links;
 @property (readwrite, nonatomic, strong) NSTextCheckingResult *activeLink;
 @property (readwrite, nonatomic, strong) NSArray *accessibilityElements;


### PR DESCRIPTION
Fixes crash in issue #436.
Solution suggested by @ChrisLoer: "That sounds similar to issue #312 , and although that issue is closed, I think there's still a potential problem with access to the nonatomic dataDetector variable from multiple threads. I use a local fork with that variable declared atomic, and for what it's worth I haven't seen any more setText crashes since introducing that change."
