### PR TITLE
Adding `attributedTruncationTokenString`.

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -238,6 +238,11 @@ extern NSString * const kTTTBackgroundCornerRadiusAttributeName;
  */
 @property (nonatomic, strong) NSDictionary *truncationTokenStringAttributes;
 
+/**
+ Manually set attributed truncation token string. If specified, `truncationTokenString` and `truncationTokenStringAttributes` will be ignored.
+ */
+@property (nonatomic, strong) NSAttributedString *attributedTruncationTokenString;
+
 
 ///--------------------------------------------
 /// @name Calculating Size of Attributed String

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -795,17 +795,24 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                         break;
                 }
 
-                NSString *truncationTokenString = self.truncationTokenString;
-                if (!truncationTokenString) {
-                    truncationTokenString = @"\u2026"; // Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026)
+                NSAttributedString *attributedTokenString;
+
+                if (self.attributedTruncationTokenString) {
+                    attributedTokenString = self.attributedTruncationTokenString;
+                } else {
+                    NSString *truncationTokenString = self.truncationTokenString;
+                    if (!truncationTokenString) {
+                        truncationTokenString = @"\u2026"; // Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026)
+                    }
+
+                    NSDictionary *truncationTokenStringAttributes = self.truncationTokenStringAttributes;
+                    if (!truncationTokenStringAttributes) {
+                        truncationTokenStringAttributes = [attributedString attributesAtIndex:(NSUInteger)truncationAttributePosition effectiveRange:NULL];
+                    }
+
+                    attributedTokenString = [[NSAttributedString alloc] initWithString:truncationTokenString attributes:truncationTokenStringAttributes];
                 }
 
-                NSDictionary *truncationTokenStringAttributes = self.truncationTokenStringAttributes;
-                if (!truncationTokenStringAttributes) {
-                    truncationTokenStringAttributes = [attributedString attributesAtIndex:(NSUInteger)truncationAttributePosition effectiveRange:NULL];
-                }
-
-                NSAttributedString *attributedTokenString = [[NSAttributedString alloc] initWithString:truncationTokenString attributes:truncationTokenStringAttributes];
                 CTLineRef truncationToken = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)attributedTokenString);
 
                 // Append truncationToken to the string


### PR DESCRIPTION
Manually set attributed truncation token string. If specified, `truncationTokenString` and `truncationTokenStringAttributes` will be ignored.
#### At a Glance

With this PR, you can make this: ...[See More](#)
('See More' has attributes but '...' don't)
#### Sample code:

``` objc
UIColor *seeMoreColor = [UIColor colorWithRed:0.04f green:0.47f blue:0x78f alpha:1.0f];
NSAttributedString *seeMore = [[NSAttributedString alloc] initWithString:@"See More" attributes:@{NSForegroundColorAttributeName: seeMoreColor}];
NSMutableAttributedString *truncationString = [[NSMutableAttributedString alloc] initWithString:@"..."];
[truncationString appendAttributedString:seeMore];

// set attributed truncation token string
self.summaryLabel.attributedTruncationTokenString = truncationString;
```

Example is not contained in this PR, so you can see full source code here: [devxoul/TTTAttributedLabel:attributed-truncation-token-string](https://github.com/devxoul/TTTAttributedLabel/tree/attributed-truncation-token-string)
#### Sample screenshot:

![ios simulator screen shot nov 11 2014 12 11 17 pm](https://cloud.githubusercontent.com/assets/931655/4987846/a559f3f8-699c-11e4-8716-d616adcf9ddc.png)
