### PR TITLE
Fix for detecting NSLinkAttributeName

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1069,10 +1069,15 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
     if (&NSLinkAttributeName) {
-        [self.attributedText enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, self.attributedText.length) options:0 usingBlock:^(id value, __unused NSRange range, __unused BOOL *stop) {
-            if (value) {
-                NSURL *URL = [value isKindOfClass:[NSString class]] ? [NSURL URLWithString:value] : value;
-                [self addLinkToURL:URL withRange:range];
+        [self.attributedText enumerateAttributesInRange:NSMakeRange(0, self.attributedText.length) options:0 usingBlock:^(NSDictionary *attrs, NSRange range, __unused BOOL *stop) {
+            for (NSString *key in attrs)
+            {
+                if ([key isEqualToString:@"NSLinkAttributeName"])
+                {
+                    id value = attrs[key];
+                    NSURL *URL = [value isKindOfClass:[NSString class]] ? [NSURL URLWithString:value] : value;
+                    [self addLinkToURL:URL withRange:range];
+                }
             }
         }];
     }


### PR DESCRIPTION
Referencing this issue: https://github.com/mattt/TTTAttributedLabel/issues/451
