### PR TITLE
Invalidate links when setAttributes: is called publically; update all inter...

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -444,13 +444,11 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 
 #pragma mark -
 
-- (void)setAttributedText:(NSAttributedString *)attributedText
-{
+- (void)setAttributedText:(NSAttributedString *)attributedText {
     [self setAttributedText:attributedText invalidateLinks:YES];
 }
 
-- (void)setAttributedText:(NSAttributedString *)text invalidateLinks:(BOOL)invalidateLinks
-{
+- (void)setAttributedText:(NSAttributedString *)text invalidateLinks:(BOOL)invalidateLinks {
     if ([text isEqualToAttributedString:_attributedText]) {
         return;
     }


### PR DESCRIPTION
This is a fix for my usage of TTTAttributedLabel in the Fitocracy app, where the reusable cells were accumulating the links because they were not invalidated when new values were set for the `attributedText` property. I thought it was useful; if you don't like this behavior just let me know and I'll throw the PR away :-)

This pull request introduces new method `setAttributes:invalidateLinks:` which resets the `links` array after changing the `_attributedText` ivar if the passed `BOOL` `invalidateLinks` is `YES`.

The implementation of `setAttributes:` calls this method with a default value of `YES` to ensure that public calls to `setAttributes:` invalidate the links.

All internal references to `setAttributes:` were changed to `setAttributes:invalidateLinks:` with the appropriate value (I believe) for `invalidateLinks` depending on the context.
