### PR TITLE
Avoid recreating the data detector

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -550,6 +550,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     if (_enabledTextCheckingTypes == enabledTextCheckingTypes) {
         return;
     }
+    
     _enabledTextCheckingTypes = enabledTextCheckingTypes;
 
     if (self.enabledTextCheckingTypes) {


### PR DESCRIPTION
Data detector creation is expensive and we can avoid recreating it with a simple check. This is particularly useful to reused cells with TTTAttributedLabel.
