### PR TITLE
Increase the hit radius for links.

### DIFF
--- a/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
+++ b/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
@@ -153,7 +153,7 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     [label addLinkToURL:testURL withRange:NSMakeRange(0, 4)];
     TTTSizeAttributedLabel(label);
     XCTAssertTrue([label containslinkAtPoint:CGPointMake(5, 5)], @"Label should contain a link at the start of the string");
-    XCTAssertFalse([label containslinkAtPoint:CGPointMake(30, 5)], @"Label should not contain a link elsewhere in the string");
+    XCTAssertFalse([label containslinkAtPoint:CGPointMake(50, 5)], @"Label should not contain a link elsewhere in the string");
 }
 
 - (void)testLinkDetection {
@@ -362,7 +362,7 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     [[TTTDelegateMock reject] attributedLabel:label didSelectLinkWithURL:testURL];
     [[TTTDelegateMock reject] attributedLabel:label didLongPressLinkWithURL:testURL atPoint:CGPointMake(30, 5)];
     
-    TTTSimulateLongPressOnLabelAtPointWithDuration(label, CGPointMake(30, 5), 0.6f);
+    TTTSimulateLongPressOnLabelAtPointWithDuration(label, CGPointMake(50, 5), 0.6f);
     
     [TTTDelegateMock verify];
 }
@@ -376,7 +376,7 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     [[TTTDelegateMock reject] attributedLabel:label didLongPressLinkWithURL:testURL atPoint:CGPointMake(30, 5)];
     
     [[[UIApplication sharedApplication].windows lastObject] addSubview:label];
-    [label dragFromPoint:CGPointMake(0, 1) toPoint:CGPointMake(30, 5) steps:30];
+    [label dragFromPoint:CGPointMake(0, 1) toPoint:CGPointMake(50, 5) steps:30];
     
     [TTTDelegateMock verify];
 }

--- a/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
+++ b/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
@@ -360,7 +360,7 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     TTTSizeAttributedLabel(label);
     
     [[TTTDelegateMock reject] attributedLabel:label didSelectLinkWithURL:testURL];
-    [[TTTDelegateMock reject] attributedLabel:label didLongPressLinkWithURL:testURL atPoint:CGPointMake(30, 5)];
+    [[TTTDelegateMock reject] attributedLabel:label didLongPressLinkWithURL:testURL atPoint:CGPointMake(50, 5)];
     
     TTTSimulateLongPressOnLabelAtPointWithDuration(label, CGPointMake(50, 5), 0.6f);
     
@@ -373,7 +373,7 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     TTTSizeAttributedLabel(label);
     
     [[TTTDelegateMock reject] attributedLabel:label didSelectLinkWithURL:testURL];
-    [[TTTDelegateMock reject] attributedLabel:label didLongPressLinkWithURL:testURL atPoint:CGPointMake(30, 5)];
+    [[TTTDelegateMock reject] attributedLabel:label didLongPressLinkWithURL:testURL atPoint:CGPointMake(50, 5)];
     
     [[[UIApplication sharedApplication].windows lastObject] addSubview:label];
     [label dragFromPoint:CGPointMake(0, 1) toPoint:CGPointMake(50, 5) steps:30];

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -644,14 +644,18 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 }
 
 - (NSTextCheckingResult *)linkAtPoint:(CGPoint)point {
+    // Approximates the behavior of UIWebView which will trigger for links on touches within 15pt of the edge.
+    return [self linkAtCharacterIndex:[self characterIndexAtPoint:point]] ?: [self linkAtRadius:7.5 aroundPoint:point] ?: [self linkAtRadius:15 aroundPoint:point];
+}
+
+- (NSTextCheckingResult *)linkAtRadius:(const CGFloat)radius aroundPoint:(CGPoint)point {
     
-    // Search for links within a reasonable radius of the touch point.
-    const CGFloat radius = 11;
+    const CGFloat diagonal = sqrt(2 * radius * radius);
+    
     const CGPoint deltas[] = {
-        CGPointMake(0, 0), // Exact point
         CGPointMake(0, -radius), CGPointMake(0, radius), // Above and below
         CGPointMake(-radius, 0), CGPointMake(radius, 0), // Beside
-        CGPointMake(-radius, -radius), CGPointMake(-radius, radius), CGPointMake(radius, radius), CGPointMake(radius, -radius) // Diagonal
+        CGPointMake(-diagonal, -diagonal), CGPointMake(-diagonal, diagonal), CGPointMake(diagonal, diagonal), CGPointMake(diagonal, -diagonal) // Diagonal
     };
     const size_t count = sizeof(deltas) / sizeof(CGPoint);
     

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -644,7 +644,25 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 }
 
 - (NSTextCheckingResult *)linkAtPoint:(CGPoint)point {
-    return [self linkAtCharacterIndex:[self characterIndexAtPoint:point]];
+    
+    // Search for links within a reasonable radius of the touch point.
+    const CGFloat radius = 11;
+    const CGPoint deltas[] = {
+        CGPointMake(0, 0), // Exact point
+        CGPointMake(0, -radius), CGPointMake(0, radius), // Above and below
+        CGPointMake(-radius, 0), CGPointMake(radius, 0), // Beside
+        CGPointMake(-radius, -radius), CGPointMake(-radius, radius), CGPointMake(radius, radius), CGPointMake(radius, -radius) // Diagonal
+    };
+    const size_t count = sizeof(deltas) / sizeof(CGPoint);
+    
+    NSTextCheckingResult *result = nil;
+    
+    for (NSInteger i = 0; i < count && result == nil; i ++) {
+        CGPoint currentPoint = CGPointMake(point.x + deltas[i].x, point.y + deltas[i].y);
+        result = [self linkAtCharacterIndex:[self characterIndexAtPoint:currentPoint]];
+    }
+    
+    return result;
 }
 
 - (NSTextCheckingResult *)linkAtCharacterIndex:(CFIndex)idx {


### PR DESCRIPTION
Small links, or regularly sized links on an iPad Mini, can be hard to tap as `characterIndexAtPoint:` only checks within the bounds of the actual character and line.  Safari on the other hand will recognize links tapped even a fair distance away from the link.

This is a simple approach that searches for links both at the center of the tap and along the edges and corners of the surrounding 22x22 square.  A more complete but more expensive approach would be to find all character rects within a certain distance of the touch point and check each for a link in increasing order of distance from the touch.