### PR TITLE
Prevent unnecessary testing on out of bounds taps.

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -652,6 +652,12 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 }
 
 - (NSTextCheckingResult *)linkAtPoint:(CGPoint)point {
+    
+    // Stop quickly if none of the points to be tested are in the bounds.
+    if (!CGRectContainsPoint(CGRectInset(self.bounds, -15.f, -15.f), point) || self.links.count == 0) {
+        return nil;
+    }
+    
     // Approximates the behavior of UIWebView which will trigger for links on touches within 15pt of the edge.
     return [self linkAtCharacterIndex:[self characterIndexAtPoint:point]]
         ?: [self linkAtRadius:2.5f aroundPoint:point]
@@ -682,6 +688,12 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 }
 
 - (NSTextCheckingResult *)linkAtCharacterIndex:(CFIndex)idx {
+    
+    // Do not enumerate if the index is outside of the bounds of the text.
+    if (!NSLocationInRange((NSUInteger)idx, NSMakeRange(0, self.attributedText.length))) {
+        return nil;
+    }
+    
     NSEnumerator *enumerator = [self.links reverseObjectEnumerator];
     NSTextCheckingResult *result = nil;
     while ((result = [enumerator nextObject])) {


### PR DESCRIPTION
From comment on #480. Added a short circuiting operations in `linkAtPoint:` and `linkAtCharacterIndex:`.

`characterIndexAtPoint:` was already fast failing when the point was outside of self.bounds so I'm failing if we're outside of the bounds plus the radius or if we don't actually have links.

I'm also failing `linkAtCharacterIndex:` if it gets an index out of bounds.  Previously it was looping through all the links even if none would match.