### PR TITLE
autodetect of links in NSAttributedString doesn't work if you setting it to TTAttributedLabel via attributedText property (fixed)

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Expecta (0.3.1)
   - FBSnapshotTestCase (1.5)
   - KIF (3.1.2):
-    - KIF/XCTest (= 3.1.2)
+    - KIF/XCTest
   - KIF/XCTest (3.1.2)
   - OCMock (3.1.2)
   - TTTAttributedLabel (1.13.1)
@@ -25,4 +25,4 @@ SPEC CHECKSUMS:
   OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f
   TTTAttributedLabel: 4c3516e4abc827aff7151a55c7964796794e11ae
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.34.4

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Expecta (0.3.1)
+  - Expecta (0.3.2)
   - FBSnapshotTestCase (1.5)
   - KIF (3.1.2):
-    - KIF/XCTest
+    - KIF/XCTest (= 3.1.2)
   - KIF/XCTest (3.1.2)
   - OCMock (3.1.2)
   - TTTAttributedLabel (1.13.1)
@@ -19,10 +19,10 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
+  Expecta: ee641011fe10aa1855d487b40e4976dac50ec342
   FBSnapshotTestCase: e2914fbaabccea1dcc773d6a16b1c24540642488
   KIF: 068074b24dd455025e7f2a488ba4fb07b9ce047b
   OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f
   TTTAttributedLabel: 4c3516e4abc827aff7151a55c7964796794e11ae
 
-COCOAPODS: 0.34.4
+COCOAPODS: 0.35.0

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -448,19 +448,26 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     if ([text isEqualToAttributedString:_attributedText]) {
         return;
     }
+        
+    [self setText: text];
+}
 
-    _attributedText = [text copy];
-
+- (void) setAttributedTextInternal:(NSAttributedString *)attributedText
+{
+    
+    _attributedText = [attributedText copy];
+    
     [self setNeedsFramesetter];
     [self setNeedsDisplay];
-
+    
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
     if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)]) {
         [self invalidateIntrinsicContentSize];
     }
 #endif
-
+    
     [super setText:[self.attributedText string]];
+
 }
 
 - (NSAttributedString *)renderedAttributedText {
@@ -1101,8 +1108,9 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
         [self setText:text afterInheritingLabelAttributesAndConfiguringWithBlock:nil];
         return;
     }
+    
+    [self setAttributedTextInternal: text];
 
-    self.attributedText = text;
     self.activeLink = nil;
 
     self.linkModels = [NSArray array];


### PR DESCRIPTION
property setter didn't affect autodect of links inside attributed string. Basically, now setAttributedText: calls setText: and everything goes fine