### PR TITLE
Add property extendedLinkTouchArea to avoid click performance problems on long texts

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -154,6 +154,11 @@ IB_DESIGNABLE
  */
 @property (nonatomic, assign) UIEdgeInsets linkBackgroundEdgeInset;
 
+/**
+ Indicates if the touches on links will be detected within an extended touch area, to emulate the behaviour of the UIWebView. Default value is YES, can be disabled to improve performance on long texts.
+ */
+@property (nonatomic, assign) BOOL extendedLinkTouchArea;
+
 ///---------------------------------------
 /// @name Acccessing Text Style Attributes
 ///---------------------------------------

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -403,6 +403,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     self.linkAttributes = [NSDictionary dictionaryWithDictionary:mutableLinkAttributes];
     self.activeLinkAttributes = [NSDictionary dictionaryWithDictionary:mutableActiveLinkAttributes];
     self.inactiveLinkAttributes = [NSDictionary dictionaryWithDictionary:mutableInactiveLinkAttributes];
+    self.extendedLinkTouchArea = YES;
     _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                                 action:@selector(longPressGestureDidFire:)];
     self.longPressGestureRecognizer.delegate = self;
@@ -672,12 +673,15 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     }
     
     // Approximates the behavior of UIWebView which will trigger for links on touches within 15pt of the edge.
-    return [self linkAtCharacterIndex:[self characterIndexAtPoint:point]]
-        ?: [self linkAtRadius:2.5f aroundPoint:point]
-        ?: [self linkAtRadius:5.f aroundPoint:point]
-        ?: [self linkAtRadius:7.5f aroundPoint:point]
-        ?: [self linkAtRadius:12.5f aroundPoint:point]
-        ?: [self linkAtRadius:15.f aroundPoint:point];
+    TTTAttributedLabelLink *result = [self linkAtCharacterIndex:[self characterIndexAtPoint:point]];
+    if(!result && self.extendedLinkTouchArea) {
+        result = [self linkAtRadius:2.5f aroundPoint:point]
+            ?: [self linkAtRadius:5.f aroundPoint:point]
+            ?: [self linkAtRadius:7.5f aroundPoint:point]
+            ?: [self linkAtRadius:12.5f aroundPoint:point]
+            ?: [self linkAtRadius:15.f aroundPoint:point];
+    }
+    return result;
 }
 
 - (TTTAttributedLabelLink *)linkAtRadius:(const CGFloat)radius aroundPoint:(CGPoint)point {


### PR DESCRIPTION
We have detected that taps on links can be really slow if we try to detect them on a wider area (trying to simulate what the ``UIWebView`` does). This can be checked if the label is inside a scrollView: when trying to scroll by tapping on the ``TTTAttributedLabel`` one can feel some delay, that can take more than one second on older devices when having longer texts (>5000 characters).

This PR adds a property that allows the programmer to choose if they want this behaviour or not.