### PR TITLE
UILineBreakModeWordWrap is deprecated: first deprecated in iOS6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pod 'TTTAttributedLabel'
 TTTAttributedLabel *label = [[TTTAttributedLabel alloc] initWithFrame:CGRectZero];
 label.font = [UIFont systemFontOfSize:14];
 label.textColor = [UIColor darkGrayColor];
-label.lineBreakMode = NSLineBreakByCharWrapping;
+label.lineBreakMode = NSLineBreakByWordWrapping;
 label.numberOfLines = 0;
 
 // If you're using a simple `NSString` for your text, 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pod 'TTTAttributedLabel'
 TTTAttributedLabel *label = [[TTTAttributedLabel alloc] initWithFrame:CGRectZero];
 label.font = [UIFont systemFontOfSize:14];
 label.textColor = [UIColor darkGrayColor];
-label.lineBreakMode = UILineBreakModeWordWrap;
+label.lineBreakMode = NSLineBreakByCharWrapping;
 label.numberOfLines = 0;
 
 // If you're using a simple `NSString` for your text, 


### PR DESCRIPTION
Hello.

Thank you for the great library. 
Would you merge my pull request?

I fixed the sample at README.
UILineBreakModeWordWrap is deprecated: first deprecated in iOS6.0
So, I changed to `NSLineBreakByCharWrapping` from `UILineBreakModeWordWrap`.