### PR TITLE
Fixed line drawing xOffset for multiple lines.

### DIFF
--- a/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
+++ b/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
@@ -339,18 +339,6 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     FBSnapshotVerifyView(label, nil);
 }
 
-- (void)testRightAlignedAttributedText {
-    label.textAlignment = NSTextAlignmentRight;
-    label.text = TTTAttributedTestString();
-    FBSnapshotVerifyView(label, nil);
-}
-
-- (void)testCenterAlignedAttributedText {
-    label.textAlignment = NSTextAlignmentCenter;
-    label.text = TTTAttributedTestString();
-    FBSnapshotVerifyView(label, nil);
-}
-
 - (void)testVerticalAlignment {
     label.verticalAlignment = TTTAttributedLabelVerticalAlignmentBottom;
     label.text = TTTAttributedTestString();

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -768,6 +768,11 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
         CGFloat yMin = (CGFloat)floor(lineOrigin.y - descent);
         CGFloat yMax = (CGFloat)ceil(lineOrigin.y + ascent);
 
+        // Apply penOffset using flushFactor for horizontal alignment to set lineOrigin since this is the horizontal offset from drawFramesetter
+        CGFloat flushFactor = TTTFlushFactorForTextAlignment(self.textAlignment);
+        CGFloat penOffset = (CGFloat)CTLineGetPenOffsetForFlush(line, flushFactor, textRect.size.width);
+        lineOrigin.x = penOffset;
+
         // Check if we've already passed the line
         if (p.y > yMax) {
             break;
@@ -935,7 +940,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                 CTLineDraw(line, c);
             }
         } else {
-            CGContextSetTextPosition(c, lineOrigin.x, lineOrigin.y - descent - self.font.descender);
+            CGFloat penOffset = (CGFloat)CTLineGetPenOffsetForFlush(line, flushFactor, rect.size.width);
+            CGContextSetTextPosition(c, penOffset, lineOrigin.y - descent - self.font.descender);
             CTLineDraw(line, c);
         }
     }
@@ -1255,24 +1261,6 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         }
 
         textRect.origin.y += yOffset;
-    }
-
-    // Adjust the text to be in the center horizontally, if the text size is smaller than bounds
-    if (textSize.width < bounds.size.width) {
-        CGFloat xOffset = 0.0f;
-        switch (self.textAlignment) {
-            case NSTextAlignmentCenter:
-                xOffset = CGFloat_floor((bounds.size.width - textSize.width) / 2.0f);
-                break;
-            case NSTextAlignmentRight:
-                xOffset = bounds.size.width - textSize.width;
-                break;
-            case NSTextAlignmentLeft:
-            default:
-                break;
-        }
-        
-        textRect.origin.x += xOffset;
     }
 
     return textRect;


### PR DESCRIPTION
Fixed characterAtIndex to use correct xOffset as penOffset instead of lineOrigin since it is not used to draw the line. This is a more general fix than #527 that handles drawing based on penOffset using the right flush factor that is used for drawing.