### PR TITLE
Only one heavy NSDataDetector instance per type (combination)

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -570,14 +570,26 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 }
 
 - (void)setEnabledTextCheckingTypes:(NSTextCheckingTypes)enabledTextCheckingTypes {
+    // one detector instance per type (combination), fast reuse e.g. in cells
+    static NSMutableDictionary *dataDetectorsByType = nil;
+
+    if (!dataDetectorsByType) {
+        dataDetectorsByType = [NSMutableDictionary dictionary];
+    }
+    
     if (self.enabledTextCheckingTypes == enabledTextCheckingTypes) {
         return;
     }
     
     _enabledTextCheckingTypes = enabledTextCheckingTypes;
-
-    if (self.enabledTextCheckingTypes) {
-        self.dataDetector = [NSDataDetector dataDetectorWithTypes:self.enabledTextCheckingTypes error:nil];
+    
+    if (enabledTextCheckingTypes) {
+        if (!dataDetectorsByType[@(enabledTextCheckingTypes)]) {
+            dataDetectorsByType[@(enabledTextCheckingTypes)] =
+                [NSDataDetector dataDetectorWithTypes:enabledTextCheckingTypes
+                                                error:nil];
+        }
+        self.dataDetector = dataDetectorsByType[@(enabledTextCheckingTypes)];
     } else {
         self.dataDetector = nil;
     }


### PR DESCRIPTION
NSDataDetector is very heavyweight and it’s unnecessary to create a
*separate* instance for every single Label. One detector can deal with
a specific type (combination) and so we can just store them in a
dictionary.

This way all Labels using the same data detection type share the same
detector instance.