### PR TITLE
Remove iOS 9 warning. 

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1175,6 +1175,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     }
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Waddress"
     if (&NSLinkAttributeName) {
         [self.attributedText enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, self.attributedText.length) options:0 usingBlock:^(id value, __unused NSRange range, __unused BOOL *stop) {
             if (value) {
@@ -1183,6 +1185,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
             }
         }];
     }
+#pragma clang diagnostic pop
 #endif
 }
 


### PR DESCRIPTION
NSLinkAttributeName address is always true in OS 7 and higher