### PR TITLE
Expose method to help with 3D touch peeking

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -448,6 +448,15 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  */
 - (BOOL)containslinkAtPoint:(CGPoint)point;
 
+/**
+ Returns the @c TTTAttributedLabelLink at the give point if it exists.
+ 
+ @discussion This can be used together with @c UIViewControllerPreviewingDelegate to peek into links.
+ 
+ @param point The point inside the label.
+ */
+- (TTTAttributedLabelLink *)linkAtPoint:(CGPoint)point;
+
 @end
 
 /**


### PR DESCRIPTION
This PR exposes the `-linkAtPoint:` method. This is useful for supporting 3D touch peeking since you'll need a reference to the URL that was 3D touched.