### PR TITLE
Fixed a bug when using accessibility

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1440,15 +1440,23 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
                 if (accessibilityLabel) {
                     TTTAccessibilityElement *linkElement = [[TTTAccessibilityElement alloc] initWithAccessibilityContainer:self];
                     linkElement.accessibilityTraits = UIAccessibilityTraitLink;
-                    linkElement.boundingRect = [self boundingRectForCharacterRange:link.result.range];
-                    linkElement.superview = self;
-                    linkElement.accessibilityLabel = accessibilityLabel;
-
-                    if (![accessibilityLabel isEqualToString:accessibilityValue]) {
-                        linkElement.accessibilityValue = accessibilityValue;
-                    }
-
-                    [mutableAccessibilityItems addObject:linkElement];
+					
+					@try {
+						linkElement.boundingRect = [self boundingRectForCharacterRange:link.result.range];
+					} @catch (NSException *exception) {
+						linkElement = nil;
+					} @finally {
+						if (linkElement) {
+							linkElement.superview = self;
+							linkElement.accessibilityLabel = accessibilityLabel;
+							
+							if (![accessibilityLabel isEqualToString:accessibilityValue]) {
+								linkElement.accessibilityValue = accessibilityValue;
+							}
+							
+							[mutableAccessibilityItems addObject:linkElement];
+						}
+					}
                 }
             }
 


### PR DESCRIPTION
When using accessibility (especially with the new XCUI testing) it resulted in a uncaught exception which led to crash the app. 947b695 fixes that. (iOS 9.1)