### PR TITLE
tvOS Support

### DIFF
--- a/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
+++ b/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
@@ -7,11 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		65C249A21BDFF9A60014AB94 /* TTTAttributedLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = A52E64F01B14C1E9002709D4 /* TTTAttributedLabel.m */; };
+		65C249A51BDFF9A60014AB94 /* TTTAttributedLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = A52E64EF1B14C1E9002709D4 /* TTTAttributedLabel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A52E64F11B14C1E9002709D4 /* TTTAttributedLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = A52E64EF1B14C1E9002709D4 /* TTTAttributedLabel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A52E64F21B14C1E9002709D4 /* TTTAttributedLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = A52E64F01B14C1E9002709D4 /* TTTAttributedLabel.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		65C249AA1BDFF9A60014AB94 /* TTTAttributedLabel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TTTAttributedLabel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A52E64271B14C0BF002709D4 /* TTTAttributedLabel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TTTAttributedLabel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A52E642B1B14C0BF002709D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A52E64EF1B14C1E9002709D4 /* TTTAttributedLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTTAttributedLabel.h; path = ../../TTTAttributedLabel/TTTAttributedLabel.h; sourceTree = "<group>"; };
@@ -19,6 +22,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		65C249A31BDFF9A60014AB94 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A52E64231B14C0BF002709D4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -41,6 +51,7 @@
 			isa = PBXGroup;
 			children = (
 				A52E64271B14C0BF002709D4 /* TTTAttributedLabel.framework */,
+				65C249AA1BDFF9A60014AB94 /* TTTAttributedLabel.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -66,6 +77,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		65C249A41BDFF9A60014AB94 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65C249A51BDFF9A60014AB94 /* TTTAttributedLabel.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A52E64241B14C0BF002709D4 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -77,6 +96,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		65C249A01BDFF9A60014AB94 /* TTTAttributedLabel tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65C249A71BDFF9A60014AB94 /* Build configuration list for PBXNativeTarget "TTTAttributedLabel tvOS" */;
+			buildPhases = (
+				65C249A11BDFF9A60014AB94 /* Sources */,
+				65C249A31BDFF9A60014AB94 /* Frameworks */,
+				65C249A41BDFF9A60014AB94 /* Headers */,
+				65C249A61BDFF9A60014AB94 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TTTAttributedLabel tvOS";
+			productName = TTTAttributedLabel;
+			productReference = 65C249AA1BDFF9A60014AB94 /* TTTAttributedLabel.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		A52E64261B14C0BF002709D4 /* TTTAttributedLabel */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A52E643D1B14C0BF002709D4 /* Build configuration list for PBXNativeTarget "TTTAttributedLabel" */;
@@ -121,11 +158,19 @@
 			projectRoot = "";
 			targets = (
 				A52E64261B14C0BF002709D4 /* TTTAttributedLabel */,
+				65C249A01BDFF9A60014AB94 /* TTTAttributedLabel tvOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		65C249A61BDFF9A60014AB94 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A52E64251B14C0BF002709D4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -136,6 +181,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		65C249A11BDFF9A60014AB94 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65C249A21BDFF9A60014AB94 /* TTTAttributedLabel.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A52E64221B14C0BF002709D4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -147,6 +200,36 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		65C249A81BDFF9A60014AB94 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = TTTAttributedLabel/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = TTTAttributedLabel;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		65C249A91BDFF9A60014AB94 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = TTTAttributedLabel/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = TTTAttributedLabel;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		A52E643B1B14C0BF002709D4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -187,7 +270,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -227,7 +310,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
+				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -268,6 +351,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		65C249A71BDFF9A60014AB94 /* Build configuration list for PBXNativeTarget "TTTAttributedLabel tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65C249A81BDFF9A60014AB94 /* Debug */,
+				65C249A91BDFF9A60014AB94 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A52E64211B14C0BF002709D4 /* Build configuration list for PBXProject "TTTAttributedLabel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
+++ b/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 				PRODUCT_NAME = TTTAttributedLabel;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
 		};
@@ -231,6 +232,7 @@
 				PRODUCT_NAME = TTTAttributedLabel;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
 		};
@@ -276,6 +278,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -316,6 +319,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
+++ b/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = TTTAttributedLabel;
+				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -226,6 +227,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = TTTAttributedLabel;
+				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -270,7 +272,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = appletvos;
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -310,7 +312,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = appletvos;
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
+++ b/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = TTTAttributedLabel/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -223,6 +224,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = TTTAttributedLabel/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Carthage/TTTAttributedLabel.xcodeproj/xcshareddata/xcschemes/TTTAttributedLabel tvOS.xcscheme
+++ b/Carthage/TTTAttributedLabel.xcodeproj/xcshareddata/xcschemes/TTTAttributedLabel tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "65C249A01BDFF9A60014AB94"
-               BuildableName = "TTTAttributedLabel tvOS.framework"
+               BuildableName = "TTTAttributedLabel.framework"
                BlueprintName = "TTTAttributedLabel tvOS"
                ReferencedContainer = "container:TTTAttributedLabel.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "65C249A01BDFF9A60014AB94"
-            BuildableName = "TTTAttributedLabel tvOS.framework"
+            BuildableName = "TTTAttributedLabel.framework"
             BlueprintName = "TTTAttributedLabel tvOS"
             ReferencedContainer = "container:TTTAttributedLabel.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "65C249A01BDFF9A60014AB94"
-            BuildableName = "TTTAttributedLabel tvOS.framework"
+            BuildableName = "TTTAttributedLabel.framework"
             BlueprintName = "TTTAttributedLabel tvOS"
             ReferencedContainer = "container:TTTAttributedLabel.xcodeproj">
          </BuildableReference>

--- a/Carthage/TTTAttributedLabel.xcodeproj/xcshareddata/xcschemes/TTTAttributedLabel tvOS.xcscheme
+++ b/Carthage/TTTAttributedLabel.xcodeproj/xcshareddata/xcschemes/TTTAttributedLabel tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "65C249A01BDFF9A60014AB94"
+               BuildableName = "TTTAttributedLabel tvOS.framework"
+               BlueprintName = "TTTAttributedLabel tvOS"
+               ReferencedContainer = "container:TTTAttributedLabel.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65C249A01BDFF9A60014AB94"
+            BuildableName = "TTTAttributedLabel tvOS.framework"
+            BlueprintName = "TTTAttributedLabel tvOS"
+            ReferencedContainer = "container:TTTAttributedLabel.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65C249A01BDFF9A60014AB94"
+            BuildableName = "TTTAttributedLabel tvOS.framework"
+            BlueprintName = "TTTAttributedLabel tvOS"
+            ReferencedContainer = "container:TTTAttributedLabel.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TTTAttributedLabel.podspec
+++ b/TTTAttributedLabel.podspec
@@ -11,5 +11,6 @@ Pod::Spec.new do |s|
   s.source_files = 'TTTAttributedLabel'
   s.requires_arc = true
   s.ios.deployment_target = '4.3'
+  s.tvos.deployment_target = '9.0'
   s.social_media_url = 'https://twitter.com/mattt'
 end

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1557,7 +1557,11 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 - (BOOL)canPerformAction:(SEL)action
               withSender:(__unused id)sender
 {
+#if !TARGET_OS_TV
     return (action == @selector(copy:));
+#else
+    return NO;
+#endif
 }
 
 - (void)touchesBegan:(NSSet *)touches
@@ -1730,13 +1734,13 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     }
 }
 
+#if !TARGET_OS_TV
 #pragma mark - UIResponderStandardEditActions
 
 - (void)copy:(__unused id)sender {
-#if !TARGET_OS_TV
     [[UIPasteboard generalPasteboard] setString:self.text];
-#endif
 }
+#endif
 
 #pragma mark - NSCoding
 

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -75,10 +75,17 @@ typedef UILineBreakMode TTTLineBreakMode;
 static inline CTTextAlignment CTTextAlignmentFromTTTTextAlignment(TTTTextAlignment alignment) {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
     switch (alignment) {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 90000
+        case NSTextAlignmentLeft: return kCTTextAlignmentLeft;
+        case NSTextAlignmentCenter: return kCTTextAlignmentCenter;
+        case NSTextAlignmentRight: return kCTTextAlignmentRight;
+        default: return kCTTextAlignmentNatural;
+#else
 		case NSTextAlignmentLeft: return kCTLeftTextAlignment;
 		case NSTextAlignmentCenter: return kCTCenterTextAlignment;
 		case NSTextAlignmentRight: return kCTRightTextAlignment;
 		default: return kCTNaturalTextAlignment;
+#endif
 	}
 #else
     switch (alignment) {

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -392,7 +392,9 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 
 - (void)commonInit {
     self.userInteractionEnabled = YES;
+#if !TARGET_OS_TV
     self.multipleTouchEnabled = NO;
+#endif
 
     self.textInsets = UIEdgeInsetsZero;
     self.lineHeightMultiple = 1.0f;
@@ -1724,7 +1726,9 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 #pragma mark - UIResponderStandardEditActions
 
 - (void)copy:(__unused id)sender {
+#if !TARGET_OS_TV
     [[UIPasteboard generalPasteboard] setString:self.text];
+#endif
 }
 
 #pragma mark - NSCoding


### PR DESCRIPTION
Hey folks!

I love TTTAttributedLabel and saw that it doesn't yet support `tvOS` in its Cocoapods podspec, so I decided to add it. It actually was fairly straightforward. If you look at the first 3 commits, you'll see that the actual changes are very minimal:

- Update podspec to announce that this pod supports tvOS
- Added compile-checks for some iOS-only things that are not allowed in tvOS <br>(mainly:  `-multitouchEnabled` and `UIPasteboard`-related)
- Fixed some warnings for `kCTTextAlignment*` (since tvOS is _always_ iOS 9.0+).

The rest of the commits were in getting the Carthage project up to date, so it can serve up both an iOS framework and a tvOS framework. I tested both integrations from my branch and verified that they work.

Thanks!