### PR TITLE
Invalidate intrinsicContentSize after setting insets

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1252,6 +1252,16 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     _inactiveLinkAttributes = convertNSAttributedStringAttributesToCTAttributes(inactiveLinkAttributes);
 }
 
+- (void)setTextInsets:(UIEdgeInsets)textInsets
+{
+    _textInsets = textInsets;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
+    if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)]) {
+        [self invalidateIntrinsicContentSize];
+    }
+#endif
+}
+
 #pragma mark - UILabel
 
 - (void)setHighlighted:(BOOL)highlighted {


### PR DESCRIPTION
I was trying to write a failing test case for this, but because invalidation and intrinsic size caching is done by the system, I got stuck.
