### PR TITLE
Expose TTTAttributedLabelLinkBlock to Swift 2.2

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -635,9 +635,10 @@ didLongPressLinkWithTextCheckingResult:(NSTextCheckingResult *)result
 
 @end
 
-@interface TTTAttributedLabelLink : NSObject <NSCoding>
 
 typedef void (^TTTAttributedLabelLinkBlock) (TTTAttributedLabel *, TTTAttributedLabelLink *);
+
+@interface TTTAttributedLabelLink : NSObject <NSCoding>
 
 /**
  An `NSTextCheckingResult` representing the link's location and type.


### PR DESCRIPTION
When exposed to Swift the TTTAttributedLabelLinkBlock is not visible in Swift 2.2 because it is hidden inside the interface TTTAttributedLabelLink. I moved the typedef out of the interface to expose it to the swift compiler.
