### PR TITLE
Add option to disable email links

### DIFF
--- a/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
+++ b/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
@@ -235,6 +235,22 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     XCTAssertEqualObjects(result.URL, testURL, @"Should set and retrieve test URL");
 }
 
+- (void)testEmailEnabledByDefault {
+    label.enabledTextCheckingTypes = NSTextCheckingTypeLink;
+    label.text = @"test@example.com";
+    
+    expect([label.links count]).will.equal(1);
+    expect(((NSTextCheckingResult *)label.links[0]).URL.absoluteString).will.equal(@"mailto:test@example.com");
+}
+
+- (void)testEmailDisabled {
+    label.enabledTextCheckingTypes = NSTextCheckingTypeLink;
+    label.emailLinksEnabled = NO;
+    label.text = @"test@example.com";
+    
+    expect([label.links count]).will.equal(0);
+}
+
 - (void)testInheritsAttributesFromLabel:(TTTAttributedLabel *)labelInstance text:(id)text {
     UIFont *testFont = [UIFont boldSystemFontOfSize:16.f];
     UIColor *testColor = [UIColor greenColor];

--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -140,6 +140,12 @@ IB_DESIGNABLE
 @property (nonatomic, assign) NSTextCheckingTypes enabledTextCheckingTypes;
 
 /**
+ Indicates whether to include email addresses when `Link` is included in `enabledTextCheckingTypes`.
+ Default value is YES.
+ */
+@property (nonatomic, assign) BOOL emailLinksEnabled;
+
+/**
  An array of `NSTextCheckingResult` objects for links detected or manually added to the label text.
  */
 @property (readonly, nonatomic, strong) NSArray *links;

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -432,6 +432,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     self.linkAttributes = [NSDictionary dictionaryWithDictionary:mutableLinkAttributes];
     self.activeLinkAttributes = [NSDictionary dictionaryWithDictionary:mutableActiveLinkAttributes];
     self.inactiveLinkAttributes = [NSDictionary dictionaryWithDictionary:mutableInactiveLinkAttributes];
+    _emailLinksEnabled = YES;
     _extendsLinkTouchArea = NO;
     _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                                 action:@selector(longPressGestureDidFire:)];
@@ -644,6 +645,10 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     NSMutableArray *links = [NSMutableArray array];
     
     for (NSTextCheckingResult *result in results) {
+        if (!self.emailLinksEnabled && [result.URL.absoluteString hasPrefix:@"mailto:"]) {
+            continue;
+        }
+        
         NSDictionary *activeAttributes = attributes ? self.activeLinkAttributes : nil;
         NSDictionary *inactiveAttributes = attributes ? self.inactiveLinkAttributes : nil;
         


### PR DESCRIPTION
When a label's `enabledTextCheckingTypes` includes the `NSTextCheckingTypeLink` all types of URLs, including email addresses, are detected and made tappable.

This pull request adds the option to disable the detection of email addresses only, while retaining the ability to link of all other types of URLs (web sites, etc.).