### PR TITLE
Attributed Truncation Token as URL Link UI fix

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -884,8 +884,12 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                 
                 NSRange linkRange;
                 if ([attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange]) {
+                    NSArray *runs = (NSArray *)CTLineGetGlyphRuns(truncatedLine);
+                    CTRunRef firstRun = (__bridge CTRunRef)runs.firstObject;
+                    CFRange leaderRange = CTRunGetStringRange(firstRun);
+                    
                     NSRange tokenRange = [truncationString.string rangeOfString:attributedTruncationString.string];
-                    NSRange tokenLinkRange = NSMakeRange((NSUInteger)(lastLineRange.location+lastLineRange.length)-tokenRange.length, (NSUInteger)tokenRange.length);
+                    NSRange tokenLinkRange = NSMakeRange((NSUInteger)(lastLineRange.location+leaderRange.position), (NSUInteger)tokenRange.length);
                     
                     [self addLinkToURL:[attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange] withRange:tokenLinkRange];
                 }

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -889,7 +889,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                     CFRange leaderRange = CTRunGetStringRange(firstRun);
                     
                     NSRange tokenRange = [truncationString.string rangeOfString:attributedTruncationString.string];
-                    NSRange tokenLinkRange = NSMakeRange((NSUInteger)(lastLineRange.location+leaderRange.position), (NSUInteger)tokenRange.length);
+                    NSRange tokenLinkRange = NSMakeRange((NSUInteger)(lastLineRange.location+leaderRange.length), (NSUInteger)tokenRange.length);
                     
                     [self addLinkToURL:[attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange] withRange:tokenLinkRange];
                 }


### PR DESCRIPTION
Correctly calculating the link range when added in the attributed truncation token.

The offset was previously calculated by taking the last line, and saying that the range of the link (and attribution token) basically started at (line length) - (attribution token length).  This only works for monospaced fonts.  My implementation looks at the first run of the truncated line, and uses its length as the starting position for the truncation token.

Here is a visual representation of the bug:

**Before**

![before](https://cloud.githubusercontent.com/assets/626090/16850287/3cfc186a-49b3-11e6-9d4e-5766ae181c26.png)
**After**

![after](https://cloud.githubusercontent.com/assets/626090/16850293/42215562-49b3-11e6-9076-047f9851d54c.png)

