### PR TITLE
Added truncation line enabled property

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -1,17 +1,17 @@
 // TTTAttributedLabel.h
 //
 // Copyright (c) 2011 Mattt Thompson (http://mattt.me)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -81,11 +81,11 @@ IB_DESIGNABLE
 
 /**
  `TTTAttributedLabel` is a drop-in replacement for `UILabel` that supports `NSAttributedString`, as well as automatically-detected and manually-added links to URLs, addresses, phone numbers, and dates.
- 
+
  ## Differences Between `TTTAttributedLabel` and `UILabel`
- 
+
  For the most part, `TTTAttributedLabel` behaves just like `UILabel`. The following are notable exceptions, in which `TTTAttributedLabel` may act differently:
- 
+
  - `text` - This property now takes an `id` type argument, which can either be a kind of `NSString` or `NSAttributedString` (mutable or immutable in both cases)
  - `attributedText` - Do not set this property directly. Instead, pass an `NSAttributedString` to `text`.
  - `lineBreakMode` - This property displays only the first line when the value is `UILineBreakModeHeadTruncation`, `UILineBreakModeTailTruncation`, or `UILineBreakModeMiddleTruncation`
@@ -93,15 +93,15 @@ IB_DESIGNABLE
  - `baselineAdjustment` - This property has no affect.
  - `textAlignment` - This property does not support justified alignment.
  - `NSTextAttachment` - This string attribute is not supported.
- 
+
  Any properties affecting text or paragraph styling, such as `firstLineIndent` will only apply when text is set with an `NSString`. If the text is set with an `NSAttributedString`, these properties will not apply.
- 
+
  ### NSCoding
- 
+
  `TTTAttributedLabel`, like `UILabel`, conforms to `NSCoding`. However, if the build target is set to less than iOS 6.0, `linkAttributes` and `activeLinkAttributes` will not be encoded or decoded. This is due to an runtime exception thrown when attempting to copy non-object CoreText values in dictionaries.
- 
+
  @warning Any properties changed on the label after setting the text will not be reflected until a subsequent call to `setText:` or `setText:afterInheritingLabelAttributesAndConfiguringWithBlock:`. This is to say, order of operations matters in this case. For example, if the label text color is originally black when the text is set, changing the text color to red will have no effect on the display of the label until the text is set once again.
- 
+
  @bug Setting `attributedText` directly is not recommended, as it may cause a crash when attempting to access any links previously set. Instead, call `setText:`, passing an `NSAttributedString`.
  */
 @interface TTTAttributedLabel : UILabel <TTTAttributedLabel, UIGestureRecognizerDelegate>
@@ -118,7 +118,7 @@ IB_DESIGNABLE
 
 /**
  The receiver's delegate.
- 
+
  @discussion A `TTTAttributedLabel` delegate responds to messages sent by tapping on links in the label. You can use the delegate to respond to links referencing a URL, address, phone number, date, or date with a specified time zone and duration.
  */
 @property (nonatomic, unsafe_unretained) IBOutlet id <TTTAttributedLabelDelegate> delegate;
@@ -141,7 +141,7 @@ IB_DESIGNABLE
 
 /**
  A dictionary containing the default `NSAttributedString` attributes to be applied to links detected or manually added to the label text. The default link style is blue and underlined.
- 
+
  @warning You must specify `linkAttributes` before setting autodecting or manually-adding links for these attributes to be applied.
  */
 @property (nonatomic, strong) NSDictionary *linkAttributes;
@@ -163,7 +163,7 @@ IB_DESIGNABLE
 
 /**
  Indicates if links will be detected within an extended area around the touch
- to emulate the link detection behaviour of UIWebView. 
+ to emulate the link detection behaviour of UIWebView.
  Default value is NO. Enabling this may adversely impact performance.
  */
 @property (nonatomic, assign) BOOL extendsLinkTouchArea;
@@ -173,19 +173,19 @@ IB_DESIGNABLE
 ///---------------------------------------
 
 /**
- The shadow blur radius for the label. A value of 0 indicates no blur, while larger values produce correspondingly larger blurring. This value must not be negative. The default value is 0. 
+ The shadow blur radius for the label. A value of 0 indicates no blur, while larger values produce correspondingly larger blurring. This value must not be negative. The default value is 0.
  */
 @property (nonatomic, assign) IBInspectable CGFloat shadowRadius;
 
-/** 
+/**
  The shadow blur radius for the label when the label's `highlighted` property is `YES`. A value of 0 indicates no blur, while larger values produce correspondingly larger blurring. This value must not be negative. The default value is 0.
  */
 @property (nonatomic, assign) IBInspectable CGFloat highlightedShadowRadius;
-/** 
+/**
  The shadow offset for the label when the label's `highlighted` property is `YES`. A size of {0, 0} indicates no offset, with positive values extending down and to the right. The default size is {0, 0}.
  */
 @property (nonatomic, assign) IBInspectable CGSize highlightedShadowOffset;
-/** 
+/**
  The shadow color for the label when the label's `highlighted` property is `YES`. The default value is `nil` (no shadow color).
  */
 @property (nonatomic, strong) IBInspectable UIColor *highlightedShadowColor;
@@ -200,8 +200,8 @@ IB_DESIGNABLE
 ///--------------------------------------------
 
 /**
- The distance, in points, from the leading margin of a frame to the beginning of the 
- paragraph's first line. This value is always nonnegative, and is 0.0 by default. 
+ The distance, in points, from the leading margin of a frame to the beginning of the
+ paragraph's first line. This value is always nonnegative, and is 0.0 by default.
  This applies to the full text, rather than any specific paragraph metrics.
  */
 @property (nonatomic, assign) IBInspectable CGFloat firstLineIndent;
@@ -238,6 +238,7 @@ IB_DESIGNABLE
  */
 @property (nonatomic, assign) TTTAttributedLabelVerticalAlignment verticalAlignment;
 
+
 ///--------------------------------------------
 /// @name Accessing Truncation Token Appearance
 ///--------------------------------------------
@@ -246,6 +247,12 @@ IB_DESIGNABLE
  The attributed string to apply to the truncation token at the end of a truncated line. Overrides `truncationTokenStringAttributes` and `truncationTokenString`. If unspecified, attributes will fallback to `truncationTokenStringAttributes` and `truncationTokenString`.
  */
 @property (nonatomic, strong) IBInspectable NSAttributedString *attributedTruncationToken;
+
+/**
+ A boolean to set if the truncation token should use a full line in the end or not.
+ */
+@property (nonatomic, assign) IBInspectable BOOL truncationLineEnabled;
+
 
 ///--------------------------
 /// @name Long press gestures
@@ -266,7 +273,7 @@ IB_DESIGNABLE
  @param attributedString The attributed string.
  @param size The maximum dimensions used to calculate size.
  @param numberOfLines The maximum number of lines in the text to draw, if the constraining size cannot accomodate the full attributed string.
- 
+
  @return The size that fits the attributed string within the specified constraints.
  */
 + (CGSize)sizeThatFitsAttributedString:(NSAttributedString *)attributedString
@@ -279,19 +286,19 @@ IB_DESIGNABLE
 
 /**
  Sets the text displayed by the label.
- 
+
  @param text An `NSString` or `NSAttributedString` object to be displayed by the label. If the specified text is an `NSString`, the label will display the text like a `UILabel`, inheriting the text styles of the label. If the specified text is an `NSAttributedString`, the label text styles will be overridden by the styles specified in the attributed string.
-  
+
  @discussion This method overrides `UILabel -setText:` to accept both `NSString` and `NSAttributedString` objects. This string is `nil` by default.
  */
 - (void)setText:(id)text;
 
 /**
  Sets the text displayed by the label, after configuring an attributed string containing the text attributes inherited from the label in a block.
- 
+
  @param text An `NSString` or `NSAttributedString` object to be displayed by the label.
  @param block A block object that returns an `NSMutableAttributedString` object and takes a single argument, which is an `NSMutableAttributedString` object with the text from the first parameter, and the text attributes inherited from the label text styles. For example, if you specified the `font` of the label to be `[UIFont boldSystemFontOfSize:14]` and `textColor` to be `[UIColor redColor]`, the `NSAttributedString` argument of the block would be contain the `NSAttributedString` attribute equivalents of those properties. In this block, you can set further attributes on particular ranges.
- 
+
  @discussion This string is `nil` by default.
  */
 - (void)setText:(id)text
@@ -303,7 +310,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  A copy of the label's current attributedText. This returns `nil` if an attributed string has never been set on the label.
- 
+
  @warning Do not set this property directly. Instead, set @c text to an @c NSAttributedString.
  */
 @property (readwrite, nonatomic, copy) NSAttributedString *attributedText;
@@ -314,28 +321,28 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Adds a link. You can customize an individual link's appearance and accessibility value by creating your own @c TTTAttributedLabelLink and passing it to this method. The other methods for adding links will use the label's default attributes.
- 
+
  @warning Modifying the link's attribute dictionaries must be done before calling this method.
- 
+
  @param link A @c TTTAttributedLabelLink object.
  */
 - (void)addLink:(TTTAttributedLabelLink *)link;
 
 /**
  Adds a link to an @c NSTextCheckingResult.
- 
+
  @param result An @c NSTextCheckingResult representing the link's location and type.
- 
+
  @return The newly added link object.
  */
 - (TTTAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
 
 /**
  Adds a link to an @c NSTextCheckingResult.
- 
+
  @param result An @c NSTextCheckingResult representing the link's location and type.
  @param attributes The attributes to be added to the text in the range of the specified link. If set, the label's @c activeAttributes and @c inactiveAttributes will be applied to the link. If `nil`, no attributes are added to the link.
- 
+
  @return The newly added link object.
  */
 - (TTTAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result
@@ -343,10 +350,10 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Adds a link to a URL for a specified range in the label text.
- 
+
  @param url The url to be linked to
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
- 
+
  @return The newly added link object.
  */
 - (TTTAttributedLabelLink *)addLinkToURL:(NSURL *)url
@@ -354,12 +361,12 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Adds a link to an address for a specified range in the label text.
- 
+
  @param addressComponents A dictionary of address components for the address to be linked to
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
- 
- @discussion The address component dictionary keys are described in `NSTextCheckingResult`'s "Keys for Address Components." 
- 
+
+ @discussion The address component dictionary keys are described in `NSTextCheckingResult`'s "Keys for Address Components."
+
  @return The newly added link object.
  */
 - (TTTAttributedLabelLink *)addLinkToAddress:(NSDictionary *)addressComponents
@@ -367,10 +374,10 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Adds a link to a phone number for a specified range in the label text.
- 
+
  @param phoneNumber The phone number to be linked to.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
- 
+
  @return The newly added link object.
  */
 - (TTTAttributedLabelLink *)addLinkToPhoneNumber:(NSString *)phoneNumber
@@ -378,10 +385,10 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Adds a link to a date for a specified range in the label text.
- 
+
  @param date The date to be linked to.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
- 
+
  @return The newly added link object.
  */
 - (TTTAttributedLabelLink *)addLinkToDate:(NSDate *)date
@@ -389,12 +396,12 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Adds a link to a date with a particular time zone and duration for a specified range in the label text.
- 
+
  @param date The date to be linked to.
  @param timeZone The time zone of the specified date.
  @param duration The duration, in seconds from the specified date.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
- 
+
  @return The newly added link object.
  */
 - (TTTAttributedLabelLink *)addLinkToDate:(NSDate *)date
@@ -407,7 +414,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
  @param components A dictionary containing the transit components. The currently supported keys are `NSTextCheckingAirlineKey` and `NSTextCheckingFlightKey`.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
- 
+
  @return The newly added link object.
  */
 - (TTTAttributedLabelLink *)addLinkToTransitInformation:(NSDictionary *)components
@@ -415,18 +422,18 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Returns whether an @c NSTextCheckingResult is found at the give point.
- 
+
  @discussion This can be used together with @c UITapGestureRecognizer to tap interactions with overlapping views.
- 
+
  @param point The point inside the label.
  */
 - (BOOL)containslinkAtPoint:(CGPoint)point;
 
 /**
  Returns the @c TTTAttributedLabelLink at the give point if it exists.
- 
+
  @discussion This can be used together with @c UIViewControllerPreviewingDelegate to peek into links.
- 
+
  @param point The point inside the label.
  */
 - (TTTAttributedLabelLink *)linkAtPoint:(CGPoint)point;
@@ -445,7 +452,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Tells the delegate that the user did select a link to a URL.
- 
+
  @param label The label whose link was selected.
  @param url The URL for the selected link.
  */
@@ -454,7 +461,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 /**
  Tells the delegate that the user did select a link to an address.
- 
+
  @param label The label whose link was selected.
  @param addressComponents The components of the address for the selected link.
  */
@@ -463,7 +470,7 @@ didSelectLinkWithAddress:(NSDictionary *)addressComponents;
 
 /**
  Tells the delegate that the user did select a link to a phone number.
- 
+
  @param label The label whose link was selected.
  @param phoneNumber The phone number for the selected link.
  */
@@ -472,7 +479,7 @@ didSelectLinkWithPhoneNumber:(NSString *)phoneNumber;
 
 /**
  Tells the delegate that the user did select a link to a date.
- 
+
  @param label The label whose link was selected.
  @param date The datefor the selected link.
  */
@@ -481,7 +488,7 @@ didSelectLinkWithPhoneNumber:(NSString *)phoneNumber;
 
 /**
  Tells the delegate that the user did select a link to a date with a time zone and duration.
- 
+
  @param label The label whose link was selected.
  @param date The date for the selected link.
  @param timeZone The time zone of the date for the selected link.
@@ -503,9 +510,9 @@ didSelectLinkWithTransitInformation:(NSDictionary *)components;
 
 /**
  Tells the delegate that the user did select a link to a text checking result.
- 
+
  @discussion This method is called if no other delegate method was called, which can occur by either now implementing the method in `TTTAttributedLabelDelegate` corresponding to a particular link, or the link was added by passing an instance of a custom `NSTextCheckingResult` subclass into `-addLinkWithTextCheckingResult:`.
- 
+
  @param label The label whose link was selected.
  @param result The custom text checking result.
  */
@@ -523,7 +530,7 @@ didSelectLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
 
 /**
  Tells the delegate that the user long-pressed a link to a URL.
- 
+
  @param label The label whose link was long pressed.
  @param url The URL for the link.
  @param point the point pressed, in the label's coordinate space
@@ -534,7 +541,7 @@ didLongPressLinkWithURL:(NSURL *)url
 
 /**
  Tells the delegate that the user long-pressed a link to an address.
- 
+
  @param label The label whose link was long pressed.
  @param addressComponents The components of the address for the link.
  @param point the point pressed, in the label's coordinate space
@@ -545,7 +552,7 @@ didLongPressLinkWithAddress:(NSDictionary *)addressComponents
 
 /**
  Tells the delegate that the user long-pressed a link to a phone number.
- 
+
  @param label The label whose link was long pressed.
  @param phoneNumber The phone number for the link.
  @param point the point pressed, in the label's coordinate space
@@ -557,7 +564,7 @@ didLongPressLinkWithPhoneNumber:(NSString *)phoneNumber
 
 /**
  Tells the delegate that the user long-pressed a link to a date.
- 
+
  @param label The label whose link was long pressed.
  @param date The date for the selected link.
  @param point the point pressed, in the label's coordinate space
@@ -569,7 +576,7 @@ didLongPressLinkWithDate:(NSDate *)date
 
 /**
  Tells the delegate that the user long-pressed a link to a date with a time zone and duration.
- 
+
  @param label The label whose link was long pressed.
  @param date The date for the link.
  @param timeZone The time zone of the date for the link.
@@ -585,7 +592,7 @@ didLongPressLinkWithDate:(NSDate *)date
 
 /**
  Tells the delegate that the user long-pressed a link to transit information.
- 
+
  @param label The label whose link was long pressed.
  @param components A dictionary containing the transit components. The currently supported keys are `NSTextCheckingAirlineKey` and `NSTextCheckingFlightKey`.
  @param point the point pressed, in the label's coordinate space
@@ -596,9 +603,9 @@ didLongPressLinkWithTransitInformation:(NSDictionary *)components
 
 /**
  Tells the delegate that the user long-pressed a link to a text checking result.
- 
+
  @discussion Similar to `-attributedLabel:didSelectLinkWithTextCheckingResult:`, this method is called if a link is long pressed and the delegate does not implement the method corresponding to this type of link.
- 
+
  @param label The label whose link was long pressed.
  @param result The custom text checking result.
  @param point the point pressed, in the label's coordinate space
@@ -640,7 +647,7 @@ typedef void (^TTTAttributedLabelLinkBlock) (TTTAttributedLabel *, TTTAttributed
 
 /**
  A block called when this link is tapped.
- If non-nil, tapping on this link will call this block instead of the 
+ If non-nil, tapping on this link will call this block instead of the
  @c TTTAttributedLabelDelegate tap methods, which will not be called for this link.
  */
 @property (nonatomic, copy) TTTAttributedLabelLinkBlock linkTapBlock;
@@ -654,12 +661,12 @@ typedef void (^TTTAttributedLabelLinkBlock) (TTTAttributedLabel *, TTTAttributed
 
 /**
  Initializes a link using the attribute dictionaries specified.
- 
+
  @param attributes         The @c attributes property for the link.
  @param activeAttributes   The @c activeAttributes property for the link.
  @param inactiveAttributes The @c inactiveAttributes property for the link.
  @param result             An @c NSTextCheckingResult representing the link's location and type.
- 
+
  @return The initialized link object.
  */
 - (instancetype)initWithAttributes:(NSDictionary *)attributes
@@ -669,10 +676,10 @@ typedef void (^TTTAttributedLabelLinkBlock) (TTTAttributedLabel *, TTTAttributed
 
 /**
  Initializes a link using the attribute dictionaries set on a specified label.
- 
+
  @param label  The attributed label from which to inherit attribute dictionaries.
  @param result An @c NSTextCheckingResult representing the link's location and type.
- 
+
  @return The initialized link object.
  */
 - (instancetype)initWithAttributesFromLabel:(TTTAttributedLabel*)label

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -392,7 +392,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     if (_highlightFramesetter) {
         CFRelease(_highlightFramesetter);
     }
-    
+
     if (_longPressGestureRecognizer) {
         [self removeGestureRecognizer:_longPressGestureRecognizer];
     }
@@ -450,7 +450,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 
 - (void)setLinkModels:(NSArray *)linkModels {
     _linkModels = linkModels;
-    
+
     self.accessibilityElements = nil;
 }
 
@@ -512,7 +512,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     if (self.enabledTextCheckingTypes == enabledTextCheckingTypes) {
         return;
     }
-    
+
     _enabledTextCheckingTypes = enabledTextCheckingTypes;
 
     // one detector instance per type (combination), fast reuse e.g. in cells
@@ -521,7 +521,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     if (!dataDetectorsByType) {
         dataDetectorsByType = [NSMutableDictionary dictionary];
     }
-    
+
     if (enabledTextCheckingTypes) {
         if (![dataDetectorsByType objectForKey:@(enabledTextCheckingTypes)]) {
             NSDataDetector *detector = [NSDataDetector dataDetectorWithTypes:enabledTextCheckingTypes
@@ -542,7 +542,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 
 - (void)addLinks:(NSArray *)links {
     NSMutableArray *mutableLinkModels = [NSMutableArray arrayWithArray:self.linkModels];
-    
+
     NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
 
     for (TTTAttributedLabelLink *link in links) {
@@ -555,7 +555,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     [self setNeedsDisplay];
 
     [mutableLinkModels addObjectsFromArray:links];
-    
+
     self.linkModels = [NSArray arrayWithArray:mutableLinkModels];
 }
 
@@ -569,21 +569,21 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                                   attributes:(NSDictionary *)attributes
 {
     NSMutableArray *links = [NSMutableArray array];
-    
+
     for (NSTextCheckingResult *result in results) {
         NSDictionary *activeAttributes = attributes ? self.activeLinkAttributes : nil;
         NSDictionary *inactiveAttributes = attributes ? self.inactiveLinkAttributes : nil;
-        
+
         TTTAttributedLabelLink *link = [[TTTAttributedLabelLink alloc] initWithAttributes:attributes
                                                                          activeAttributes:activeAttributes
                                                                        inactiveAttributes:inactiveAttributes
                                                                        textCheckingResult:result];
-        
+
         [links addObject:link];
     }
-    
+
     [self addLinks:links];
-    
+
     return links;
 }
 
@@ -636,14 +636,14 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 }
 
 - (TTTAttributedLabelLink *)linkAtPoint:(CGPoint)point {
-    
+
     // Stop quickly if none of the points to be tested are in the bounds.
     if (!CGRectContainsPoint(CGRectInset(self.bounds, -15.f, -15.f), point) || self.links.count == 0) {
         return nil;
     }
-    
+
     TTTAttributedLabelLink *result = [self linkAtCharacterIndex:[self characterIndexAtPoint:point]];
-    
+
     if (!result && self.extendsLinkTouchArea) {
         result = [self linkAtRadius:2.5f aroundPoint:point]
               ?: [self linkAtRadius:5.f aroundPoint:point]
@@ -651,7 +651,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
               ?: [self linkAtRadius:12.5f aroundPoint:point]
               ?: [self linkAtRadius:15.f aroundPoint:point];
     }
-    
+
     return result;
 }
 
@@ -664,14 +664,14 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
         CGPointMake(diagonal, diagonal), CGPointMake(diagonal, -diagonal) // Diagonal
     };
     const size_t count = sizeof(deltas) / sizeof(CGPoint);
-    
+
     TTTAttributedLabelLink *link = nil;
-    
+
     for (NSInteger i = 0; i < count && link.result == nil; i ++) {
         CGPoint currentPoint = CGPointMake(point.x + deltas[i].x, point.y + deltas[i].y);
         link = [self linkAtCharacterIndex:[self characterIndexAtPoint:currentPoint]];
     }
-    
+
     return link;
 }
 
@@ -680,7 +680,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     if (!NSLocationInRange((NSUInteger)idx, NSMakeRange(0, self.attributedText.length))) {
         return nil;
     }
-    
+
     NSEnumerator *enumerator = [self.linkModels reverseObjectEnumerator];
     TTTAttributedLabelLink *link = nil;
     while ((link = [enumerator nextObject])) {
@@ -845,26 +845,32 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                 NSAttributedString *attributedTruncationString = self.attributedTruncationToken;
                 if (!attributedTruncationString) {
                     NSString *truncationTokenString = @"\u2026"; // Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026)
-                    
+
                     NSDictionary *truncationTokenStringAttributes = truncationTokenStringAttributes = [attributedString attributesAtIndex:(NSUInteger)truncationAttributePosition effectiveRange:NULL];
-                    
+
                     attributedTruncationString = [[NSAttributedString alloc] initWithString:truncationTokenString attributes:truncationTokenStringAttributes];
                 }
                 CTLineRef truncationToken = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)attributedTruncationString);
 
-                // Append truncationToken to the string
-                // because if string isn't too long, CT won't add the truncationToken on its own.
-                // There is no chance of a double truncationToken because CT only adds the
-                // token if it removes characters (and the one we add will go first)
-                NSMutableAttributedString *truncationString = [[NSMutableAttributedString alloc] initWithAttributedString:
-                                                               [attributedString attributedSubstringFromRange:
-                                                                NSMakeRange((NSUInteger)lastLineRange.location,
-                                                                            (NSUInteger)lastLineRange.length)]];
-                if (lastLineRange.length > 0) {
-                    // Remove any newline at the end (we don't want newline space between the text and the truncation token). There can only be one, because the second would be on the next line.
-                    unichar lastCharacter = [[truncationString string] characterAtIndex:(NSUInteger)(lastLineRange.length - 1)];
-                    if ([[NSCharacterSet newlineCharacterSet] characterIsMember:lastCharacter]) {
-                        [truncationString deleteCharactersInRange:NSMakeRange((NSUInteger)(lastLineRange.length - 1), 1)];
+                NSMutableAttributedString *truncationString;
+
+                if (self.truncationLineEnabled) {
+                    truncationString = [[NSMutableAttributedString alloc] initWithString: @""];
+                } else {
+                    // Append truncationToken to the string
+                    // because if string isn't too long, CT won't add the truncationToken on its own.
+                    // There is no chance of a double truncationToken because CT only adds the
+                    // token if it removes characters (and the one we add will go first)
+                    truncationString = [[NSMutableAttributedString alloc] initWithAttributedString:
+                                                                   [attributedString attributedSubstringFromRange:
+                                                                    NSMakeRange((NSUInteger)lastLineRange.location,
+                                                                                (NSUInteger)lastLineRange.length)]];
+                    if (lastLineRange.length > 0) {
+                        // Remove any newline at the end (we don't want newline space between the text and the truncation token). There can only be one, because the second would be on the next line.
+                        unichar lastCharacter = [[truncationString string] characterAtIndex:(NSUInteger)(lastLineRange.length - 1)];
+                        if ([[NSCharacterSet newlineCharacterSet] characterIsMember:lastCharacter]) {
+                            [truncationString deleteCharactersInRange:NSMakeRange((NSUInteger)(lastLineRange.length - 1), 1)];
+                        }
                     }
                 }
                 [truncationString appendAttributedString:attributedTruncationString];
@@ -881,12 +887,12 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                 CGContextSetTextPosition(c, penOffset, lineOrigin.y - descent - self.font.descender);
 
                 CTLineDraw(truncatedLine, c);
-                
+
                 NSRange linkRange;
                 if ([attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange]) {
                     NSRange tokenRange = [truncationString.string rangeOfString:attributedTruncationString.string];
                     NSRange tokenLinkRange = NSMakeRange((NSUInteger)(lastLineRange.location+lastLineRange.length)-tokenRange.length, (NSUInteger)tokenRange.length);
-                    
+
                     [self addLinkToURL:[attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange] withRange:tokenLinkRange];
                 }
 
@@ -1123,7 +1129,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 
 - (void)setActiveLink:(TTTAttributedLabelLink *)activeLink {
     _activeLink = activeLink;
-    
+
     NSDictionary *activeAttributes = activeLink.activeAttributes ?: self.activeLinkAttributes;
 
     if (_activeLink && activeAttributes.count > 0) {
@@ -1241,11 +1247,11 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         // See #393.
         [self setNeedsFramesetter];
         [self setNeedsDisplay];
-        
+
         if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)]) {
             [self invalidateIntrinsicContentSize];
         }
-        
+
         // Use infinite width to find the max width, which will be compared to availableWidth if needed.
         CGSize maxSize = (self.numberOfLines > 1) ? CGSizeMake(TTTFLOAT_MAX, TTTFLOAT_MAX) : CGSizeZero;
 
@@ -1340,11 +1346,11 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
             NSMutableArray *mutableAccessibilityItems = [NSMutableArray array];
 
             for (TTTAttributedLabelLink *link in self.linkModels) {
-                
+
                 if (link.result.range.location == NSNotFound) {
                     continue;
                 }
-                
+
                 NSString *sourceText = [self.text isKindOfClass:[NSString class]] ? self.text : [(NSAttributedString *)self.text string];
 
                 NSString *accessibilityLabel = [sourceText substringWithRange:link.result.range];
@@ -1389,13 +1395,13 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         return [super sizeThatFits:size];
     } else {
         NSMutableAttributedString *fullString = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
-        
+
         if (self.attributedTruncationToken) {
             [fullString appendAttributedString:self.attributedTruncationToken];
         }
-        
+
         NSAttributedString *string = [[NSAttributedString alloc] initWithAttributedString:fullString];
-        
+
         CGSize labelSize = CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints([self framesetter], string, size, (NSUInteger)self.numberOfLines);
         labelSize.width += self.textInsets.left + self.textInsets.right;
         labelSize.height += self.textInsets.top + self.textInsets.bottom;
@@ -1420,7 +1426,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     for (TTTAttributedLabelLink *link in self.linkModels) {
         NSDictionary *attributesToRemove = isInactive ? link.attributes : link.inactiveAttributes;
         NSDictionary *attributesToAdd = isInactive ? link.inactiveAttributes : link.attributes;
-        
+
         [attributesToRemove enumerateKeysAndObjectsUsingBlock:^(NSString *name, __unused id value, __unused BOOL *stop) {
             if (NSMaxRange(link.result.range) <= mutableAttributedString.length) {
                 [mutableAttributedString removeAttribute:name range:link.result.range];
@@ -1500,7 +1506,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
             self.activeLink = nil;
             return;
         }
-        
+
         NSTextCheckingResult *result = self.activeLink.result;
         self.activeLink = nil;
 
@@ -1573,19 +1579,19 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         case UIGestureRecognizerStateBegan: {
             CGPoint touchPoint = [sender locationInView:self];
             TTTAttributedLabelLink *link = [self linkAtPoint:touchPoint];
-            
+
             if (link) {
                 if (link.linkLongPressBlock) {
                     link.linkLongPressBlock(self, link);
                     return;
                 }
-                
+
                 NSTextCheckingResult *result = link.result;
-                
+
                 if (!result) {
                     return;
                 }
-                
+
                 switch (result.resultType) {
                     case NSTextCheckingTypeLink:
                         if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithURL:atPoint:)]) {
@@ -1622,7 +1628,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
                     default:
                         break;
                 }
-                
+
                 // Fallback to `attributedLabel:didLongPressLinkWithTextCheckingResult:atPoint:` if no other delegate method matched.
                 if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithTextCheckingResult:atPoint:)]) {
                     [self.delegate attributedLabel:self didLongPressLinkWithTextCheckingResult:result atPoint:touchPoint];
@@ -1668,6 +1674,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     [coder encodeInteger:self.verticalAlignment forKey:NSStringFromSelector(@selector(verticalAlignment))];
 
     [coder encodeObject:self.attributedTruncationToken forKey:NSStringFromSelector(@selector(attributedTruncationToken))];
+    [coder encodeBool:self.truncationLineEnabled forKey:NSStringFromSelector(@selector(truncationLineEnabled))];
 
     [coder encodeObject:NSStringFromUIEdgeInsets(self.linkBackgroundEdgeInset) forKey:NSStringFromSelector(@selector(linkBackgroundEdgeInset))];
     [coder encodeObject:self.attributedText forKey:NSStringFromSelector(@selector(attributedText))];
@@ -1761,6 +1768,10 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         self.attributedTruncationToken = [coder decodeObjectForKey:NSStringFromSelector(@selector(attributedTruncationToken))];
     }
 
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(truncationLineEnabled))]) {
+        self.truncationLineEnabled = [coder decodeBoolForKey:NSStringFromSelector(@selector(truncationLineEnabled))];
+    }
+
     if ([coder containsValueForKey:NSStringFromSelector(@selector(linkBackgroundEdgeInset))]) {
         self.linkBackgroundEdgeInset = UIEdgeInsetsFromString([coder decodeObjectForKey:NSStringFromSelector(@selector(linkBackgroundEdgeInset))]);
     }
@@ -1770,7 +1781,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     } else {
         self.text = super.text;
     }
-    
+
     return self;
 }
 
@@ -1784,20 +1795,20 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
                   activeAttributes:(NSDictionary *)activeAttributes
                 inactiveAttributes:(NSDictionary *)inactiveAttributes
                 textCheckingResult:(NSTextCheckingResult *)result {
-    
+
     if ((self = [super init])) {
         _result = result;
         _attributes = [attributes copy];
         _activeAttributes = [activeAttributes copy];
         _inactiveAttributes = [inactiveAttributes copy];
     }
-    
+
     return self;
 }
 
 - (instancetype)initWithAttributesFromLabel:(TTTAttributedLabel*)label
                          textCheckingResult:(NSTextCheckingResult *)result {
-    
+
     return [self initWithAttributes:label.linkAttributes
                    activeAttributes:label.activeLinkAttributes
                  inactiveAttributes:label.inactiveLinkAttributes
@@ -1824,7 +1835,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
                 break;
         }
     }
-    
+
     return _accessibilityValue;
 }
 
@@ -1846,13 +1857,13 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         _inactiveAttributes = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(inactiveAttributes))];
         self.accessibilityValue = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(accessibilityValue))];
     }
-    
+
     return self;
 }
 
 @end
 
-#pragma mark - 
+#pragma mark -
 
 static inline CGColorRef CGColorRefFromColor(id color) {
     return [color isKindOfClass:[UIColor class]] ? [color CGColor] : (__bridge CGColorRef)color;
@@ -1865,9 +1876,9 @@ static inline CTFontRef CTFontRefFromUIFont(UIFont * font) {
 
 static inline NSDictionary * convertNSAttributedStringAttributesToCTAttributes(NSDictionary *attributes) {
     if (!attributes) return nil;
-    
+
     NSMutableDictionary *mutableAttributes = [NSMutableDictionary dictionary];
-    
+
     NSDictionary *NSToCTAttributeNamesMap = @{
         NSFontAttributeName:            (NSString *)kCTFontAttributeName,
         NSBackgroundColorAttributeName: (NSString *)kTTTBackgroundFillColorAttributeName,
@@ -1879,10 +1890,10 @@ static inline NSDictionary * convertNSAttributedStringAttributesToCTAttributes(N
         NSKernAttributeName:            (NSString *)kCTKernAttributeName,
         NSLigatureAttributeName:        (NSString *)kCTLigatureAttributeName
     };
-    
+
     [attributes enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
         key = [NSToCTAttributeNamesMap objectForKey:key] ? : key;
-        
+
         if (![NSMutableParagraphStyle class]) {
             if ([value isKindOfClass:[UIFont class]]) {
                 value = (__bridge id)CTFontRefFromUIFont(value);
@@ -1890,9 +1901,9 @@ static inline NSDictionary * convertNSAttributedStringAttributesToCTAttributes(N
                 value = (__bridge id)((UIColor *)value).CGColor;
             }
         }
-        
+
         [mutableAttributes setObject:value forKey:key];
     }];
-    
+
     return [NSDictionary dictionaryWithDictionary:mutableAttributes];
 }


### PR DESCRIPTION
I needed a way to provide the behavior as seen below:

![simulator screen shot 04 aug 2016 11 32 23](https://cloud.githubusercontent.com/assets/4968178/17398911/2bc895d4-5a37-11e6-9921-06e06be10820.png)

In order to accomplish this, aside from setting the `attributedTruncationToken` to a custom token `Read All`, I added a property to `TTTAttributedLabel` to be able to set a truncation token to occupy the whole last line. The parameter added is `truncationLineEnabled`. 