### PR TITLE
Add Carthage Bitcode support

### DIFF
--- a/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
+++ b/Carthage/TTTAttributedLabel.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -288,6 +289,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Should fix #593 by adding `BITCODE_GENERATION_MODE=bitcode` to the `User Defined Settings` of `Carthage/TTTAttributedLabel.xcodeproj`, so it will work for current and future targets.
- For more details about the problem see Carthage/Carthage#535
- For an example of another project's implementation see SwiftyJSON/SwiftyJSON#356 (note: they modify the targets' settings, I modified the project's settings)
