### PR TITLE
Fixes zero size issue when using an attributedTruncationToken

### DIFF
--- a/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
+++ b/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
@@ -26,6 +26,11 @@ static inline NSAttributedString * TTTAttributedTestString() {
                                            attributes:TTTAttributedTestAttributesDictionary()];
 }
 
+static inline NSAttributedString * TTTAttributedTruncationTokenString() {
+    return [[NSAttributedString alloc] initWithString:@"+++"
+                                           attributes:TTTAttributedTestAttributesDictionary()];
+}
+
 static inline void TTTSizeAttributedLabel(TTTAttributedLabel *label) {
     CGSize size = [TTTAttributedLabel sizeThatFitsAttributedString:label.attributedText
                                                    withConstraints:kTestLabelSize
@@ -194,6 +199,19 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
                                      limitedToNumberOfLines:2];
     
     font = [testString attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
+    XCTAssertGreaterThan(size.height, font.pointSize, @"Text should size to more than one line");
+}
+
+- (void)testMultilineLabelSizeThatFitsWithTruncationToken {
+    NSAttributedString *testString = TTTAttributedTestString();
+    label.text = testString;
+    
+    NSAttributedString *tokenString = TTTAttributedTruncationTokenString();
+    label.attributedTruncationToken = tokenString;
+    
+    CGSize size = [label sizeThatFits:kTestLabelSize];
+    
+    UIFont *font = [testString attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
     XCTAssertGreaterThan(size.height, font.pointSize, @"Text should size to more than one line");
 }
 

--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -243,7 +243,7 @@ IB_DESIGNABLE
 ///--------------------------------------------
 
 /**
- The attributed string to apply to the truncation token at the end of a truncated line. Overrides `truncationTokenStringAttributes` and `truncationTokenString`. If unspecified, attributes will fallback to `truncationTokenStringAttributes` and `truncationTokenString`.
+ The attributed string to apply to the truncation token at the end of a truncated line.
  */
 @property (nonatomic, strong) IBInspectable NSAttributedString *attributedTruncationToken;
 

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -173,7 +173,10 @@ static inline NSDictionary * NSAttributedStringAttributesFromLabel(TTTAttributed
         CTParagraphStyleSetting paragraphStyles[12] = {
             {.spec = kCTParagraphStyleSpecifierAlignment, .valueSize = sizeof(CTTextAlignment), .value = (const void *)&alignment},
             {.spec = kCTParagraphStyleSpecifierLineBreakMode, .valueSize = sizeof(CTLineBreakMode), .value = (const void *)&lineBreakMode},
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             {.spec = kCTParagraphStyleSpecifierLineSpacing, .valueSize = sizeof(CGFloat), .value = (const void *)&lineSpacing},
+#pragma clang diagnostic pop
             {.spec = kCTParagraphStyleSpecifierMinimumLineSpacing, .valueSize = sizeof(CGFloat), .value = (const void *)&minimumLineHeight},
             {.spec = kCTParagraphStyleSpecifierMaximumLineSpacing, .valueSize = sizeof(CGFloat), .value = (const void *)&maximumLineHeight},
             {.spec = kCTParagraphStyleSpecifierLineSpacingAdjustment, .valueSize = sizeof (CGFloat), .value = (const void *)&lineSpacingAdjustment},

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1395,10 +1395,13 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         }
         
         NSAttributedString *string = [[NSAttributedString alloc] initWithAttributedString:fullString];
+        CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)string);
         
-        CGSize labelSize = CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints([self framesetter], string, size, (NSUInteger)self.numberOfLines);
+        CGSize labelSize = CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints(framesetter, string, size, (NSUInteger)self.numberOfLines);
         labelSize.width += self.textInsets.left + self.textInsets.right;
         labelSize.height += self.textInsets.top + self.textInsets.bottom;
+        
+        CFRelease(framesetter);
 
         return labelSize;
     }


### PR DESCRIPTION
Fixes sizeThatFits issue where the size returned was 0 when using an attributedTruncationToken.

Addresses: #621 and #678.

You can run the test from commit [2be9753] to see the size being returned as (0, 0). Re-run the test with commit [	93cb76d] to see the test pass.