### PR TITLE
Fix size that fits text insets

### DIFF
--- a/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
+++ b/Example/TTTAttributedLabelTests/TTTAttributedLabelTests.m
@@ -92,6 +92,35 @@ static inline void TTTSimulateLongPressOnLabelAtPointWithDuration(TTTAttributedL
     expect([label intrinsicContentSize]).to.equal([label sizeThatFits:CGSizeZero]);
 }
 
+- (void)testSizeThatFits {
+    label.text = TTTAttributedTestString();
+    label.numberOfLines = 0;
+    
+    CGSize sizeWithoutInsets = [label sizeThatFits:CGSizeMake(1000, 1000)];
+    expect(sizeWithoutInsets.width).to.beLessThanOrEqualTo(1000);
+    expect(sizeWithoutInsets.height).to.beLessThanOrEqualTo(1000);
+    
+    // Force multiline label by asking for a width smaller than the required
+    CGSize multilineMeasurementSize = CGSizeMake(sizeWithoutInsets.width - 1, 1000);
+    CGSize sizeWithoutInsetsMultiline = [label sizeThatFits:multilineMeasurementSize];
+    expect(sizeWithoutInsetsMultiline.width).to.beLessThanOrEqualTo(multilineMeasurementSize.width);
+    expect(sizeWithoutInsetsMultiline.width).to.beGreaterThan(sizeWithoutInsets.height);
+    
+    // repeat test by setting insets
+    
+    label.textInsets = UIEdgeInsetsMake(10, 20, 30, 40);
+    CGSize sizeWithInsets = [label sizeThatFits:CGSizeMake(sizeWithoutInsets.width, 1000)];
+    expect(sizeWithInsets.width).to.beLessThan(sizeWithoutInsets.width); // has to be smaller because of the insets
+    expect(sizeWithInsets.height).to.beGreaterThan(sizeWithoutInsets.height);
+    expect(sizeWithInsets.width).to.beLessThanOrEqualTo(1000);
+    expect(sizeWithInsets.height).to.beLessThanOrEqualTo(1000);
+    
+    multilineMeasurementSize = CGSizeMake(sizeWithInsets.width - 1, 1000);
+    CGSize sizeWithInsetsMultiline = [label sizeThatFits:CGSizeMake(300, 1000)];
+    expect(sizeWithInsetsMultiline.width).to.beLessThanOrEqualTo(multilineMeasurementSize.width);
+    expect(sizeWithInsetsMultiline.width).to.beGreaterThan(sizeWithoutInsets.height);
+}
+
 - (void)testHighlighting {
     label.text = TTTAttributedTestString();
     [label setHighlighted:YES];

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1321,13 +1321,15 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     if (!self.attributedText) {
         return [super sizeThatFits:size];
     } else {
-        NSMutableAttributedString *fullString = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
-        
+        NSAttributedString *string;
         if (self.attributedTruncationToken) {
+            NSMutableAttributedString *fullString = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
             [fullString appendAttributedString:self.attributedTruncationToken];
+            string = [fullString copy];
+        } else {
+            string = self.attributedText;
         }
         
-        NSAttributedString *string = [[NSAttributedString alloc] initWithAttributedString:fullString];
         size.width -= self.textInsets.left + self.textInsets.right;
         size.height -= self.textInsets.top + self.textInsets.bottom;
         

--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1328,6 +1328,8 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
         }
         
         NSAttributedString *string = [[NSAttributedString alloc] initWithAttributedString:fullString];
+        size.width -= self.textInsets.left + self.textInsets.right;
+        size.height -= self.textInsets.top + self.textInsets.bottom;
         
         CGSize labelSize = CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints([self framesetter], string, size, (NSUInteger)self.numberOfLines);
         labelSize.width += self.textInsets.left + self.textInsets.right;


### PR DESCRIPTION
Fixes the issue of size not properly computed when `textInsets` have a value different to `UIEdgeInsetsZero`, which could provoke the following bug:

![screen shot 2016-11-17 at 16 49 12](https://cloud.githubusercontent.com/assets/1763948/20396218/cb6d67e4-ace5-11e6-9461-027a02f6e380.png)

A test has been added to prove that the fix works. There is also a change to avoid an unnecessary allocation inside `sizeThatFits:` when the `attributedTruncationToken` is not set.

Thanks for this great library!