### PR TITLE
Fix crash when attribute NSLinkAttributeName is kind of NSString

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -826,8 +826,12 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                 if ([attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange]) {
                     NSRange tokenRange = [truncationString.string rangeOfString:attributedTruncationString.string];
                     NSRange tokenLinkRange = NSMakeRange((NSUInteger)(lastLineRange.location+lastLineRange.length)-tokenRange.length, (NSUInteger)tokenRange.length);
-                    
-                    [self addLinkToURL:[attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange] withRange:tokenLinkRange];
+                    id attribute = [attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange];
+                    if (attribute) {
+                        // NSLinkAttributeName can be NSURL or NSString
+                        NSURL *URL = [attribute isKindOfClass:[NSString class]] ? [NSURL URLWithString:attribute] : attribute;
+                        [self addLinkToURL:URL withRange:tokenLinkRange];
+                    }
                 }
 
                 CFRelease(truncatedLine);


### PR DESCRIPTION
TTTAttributedLabel does not handle `NSLinkAttributeName` attribute is kind of `NSString`, so it will use a NSString type value to init `NSLinkCheckingResult` by `[NSTextCheckingResult linkCheckingResultWithRange:range URL:url]; // url is kind of NSString`.

```
    switch (result.resultType) {
            case NSTextCheckingTypeLink:
                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
                    [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL]; // the result.URL is kind of NSString, not NSURL
                    return;
                }
                break;
```