### PR TITLE
[Fix] Accessibility element's bounding rect will get wrong if the con…

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -713,7 +713,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
     [textStorage addLayoutManager:layoutManager];
 
-    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:self.bounds.size];
+    CGSize containerSize = self.bounds.size;
+    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:CGSizeMake(containerSize.width, CGFLOAT_MAX)];
     [layoutManager addTextContainer:textContainer];
 
     NSRange glyphRange;


### PR DESCRIPTION
Repro steps:
1. Using AddLinkToURL: to add two urls inside the text, such as ‘Affogato’ and ‘mylink’ and the text should contain ‘\n’ character
label.text = @"Affogato: Espresso served over gelato. Traditionally vanilla is used, but some coffeehouses or customers use any flavor \n \n 123 mylink.";

2. If the label’s layout was not set correctly before adding the link, the last accessibility element will get the wrong boundingRect (all zero) from the return value of boundingREctForCharacterRange:
3. boundingREctForCharacterRange: using label’s bounding size to measure the position of the highlighted element but the textContainer seems to ignore the ‘\n’ character will have additional line.
4. Thus, if user setting the correct frame such as using sizeToFit, it works fine. But if the user calls it later after adding the link, the position of accessibilityElement will get wrong.

Solution:
NSTextContainer’s size does not need to be the same as the label’s bounding size.
Instead, we can use
CGSizeMake(self.bounds.size.width, CGFLOAT_MAX)